### PR TITLE
Yufeng

### DIFF
--- a/allvars.h
+++ b/allvars.h
@@ -555,8 +555,6 @@ extern struct global_data_all_processes
     double WindFreeTravelLength;
     double WindFreeTravelDensFac;
     double FactorForSofterEQS;
-    double QuickLymanAlphaProbability;
-
     /* used in VS08 and SH03*/
     double WindEfficiency;
     double WindSpeed;
@@ -565,6 +563,13 @@ extern struct global_data_all_processes
     double WindSigma0;
     double WindSpeedFactor;
 #endif
+    /*Lyman alpha forest specific parameters*/
+    double QuickLymanAlphaProbability;
+    int HeliumHeatOn;
+    double HeliumHeatThresh;
+    double HeliumHeatAmp;
+    double HeliumHeatExp;
+
 
 #ifdef BLACK_HOLES
     double BlackHoleAccretionFactor;	/*!< Fraction of BH bondi accretion rate */

--- a/allvars.h
+++ b/allvars.h
@@ -422,7 +422,6 @@ extern struct global_data_all_processes
         double fac_egy;
         double hubble;
         double hubble_a2;
-        double D1;
     } cf;
 
     /* variables for organizing discrete timeline */

--- a/allvars.h
+++ b/allvars.h
@@ -389,6 +389,7 @@ extern struct global_data_all_processes
     int CoolingOn;		/*!< flags that cooling is enabled */
     double UVRedshiftThreshold;		/* Initial redshift of UV background. */
     int HydroOn;		/*!< flags that hydro force is enabled */
+    int DensityOn;		/*!< flags that SPH density computation is enabled */
     int TreeGravOn;          /*!< flags that tree gravity force is enabled*/
     int BlackHoleOn;		/*!< flags that black holes are enabled */
     int StarformationOn;		/*!< flags that star formation is enabled */

--- a/density.c
+++ b/density.c
@@ -102,6 +102,8 @@ static void density_copy(int place, TreeWalkQueryDensity * I);
 
 void density(void)
 {
+    if(!All.DensityOn)
+	return;
     TreeWalk tw[1] = {0};
 
     tw->ev_label = "DENSITY";

--- a/gravpm.c
+++ b/gravpm.c
@@ -63,7 +63,7 @@ void gravpm_force() {
     powerspectrum_sum(&PowerSpectrum, All.BoxSize*All.UnitLength_in_cm);
     /*Now save the power spectrum*/
     if(ThisTask == 0)
-        powerspectrum_save(&PowerSpectrum, All.OutputDir, All.Time, All.cf.D1);
+        powerspectrum_save(&PowerSpectrum, All.OutputDir, All.Time, GrowthFactor(All.Time));
 }
 
 static double pot_factor;

--- a/param.c
+++ b/param.c
@@ -175,6 +175,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "UVRedshiftThreshold", OPTIONAL, -1.0, "Earliest Redshift that UV background is enabled. This modulates UVFluctuation and TreeCool globally. Default -1.0 means no modulation.");
 
     param_declare_int(ps, "HydroOn", REQUIRED, 1, "Enables hydro force");
+    param_declare_int(ps, "DensityOn", OPTIONAL, 1, "Enables SPH density computation.");
     param_declare_int(ps, "TreeGravOn", OPTIONAL, 1, "Enables tree gravity");
     param_declare_int(ps, "StarformationOn", REQUIRED, 0, "Enables star formation");
     param_declare_int(ps, "RadiationOn", OPTIONAL, 0, "Include radiation density in the background evolution.");
@@ -378,6 +379,7 @@ void read_parameter_file(char *fname)
         All.CoolingOn = param_get_int(ps, "CoolingOn");
         All.UVRedshiftThreshold = param_get_double(ps, "UVRedshiftThreshold");
         All.HydroOn = param_get_int(ps, "HydroOn");
+        All.DensityOn = param_get_int(ps, "DensityOn");
         All.TreeGravOn = param_get_int(ps, "TreeGravOn");
         All.FastParticleType = param_get_int(ps, "FastParticleType");
         All.NoTreeType = param_get_int(ps, "NoTreeType");

--- a/param.c
+++ b/param.c
@@ -283,11 +283,14 @@ create_gadget_parameter_set()
     param_declare_double(ps, "WindFreeTravelDensFac", OPTIONAL, 0., "");
 
     /*These parameters are Lyman alpha forest specific*/
-    param_declare_double(ps, "QuickLymanAlphaProbability", OPTIONAL, 0, "");
-    param_declare_int(ps, "HeliumHeatOn", OPTIONAL, 0, "");
-    param_declare_double(ps, "HeliumHeatThresh", OPTIONAL, 10, "");
-    param_declare_double(ps, "HeliumHeatAmp", OPTIONAL, 1, "");
-    param_declare_double(ps, "HeliumHeatExp", OPTIONAL, 0, "");
+    param_declare_double(ps, "QuickLymanAlphaProbability", OPTIONAL, 0, "Probability gas is turned directly into stars, irrespective of pressure. One is equivalent to quick lyman alpha star formation.");
+    /* Enable model for helium reionisation which adds extra photo-heating to under-dense gas.
+     * Extra heating has the form: H = Amp * (rho / rho_c(z=0))^Exp
+     * but is density-independent when rho / rho_c > Thresh. */
+    param_declare_int(ps, "HeliumHeatOn", OPTIONAL, 0, "Change photo-heating rate to model helium reionisation on underdense gas.");
+    param_declare_double(ps, "HeliumHeatThresh", OPTIONAL, 10, "Overdensity above which heating is density-independent.");
+    param_declare_double(ps, "HeliumHeatAmp", OPTIONAL, 1, "Density-independent heat boost. Changes mean temperature.");
+    param_declare_double(ps, "HeliumHeatExp", OPTIONAL, 0, "Density dependent heat boost (exponent). Changes gamma.");
 
 #endif
 

--- a/param.c
+++ b/param.c
@@ -282,7 +282,12 @@ create_gadget_parameter_set()
     param_declare_double(ps, "WindFreeTravelLength", OPTIONAL, 20, "");
     param_declare_double(ps, "WindFreeTravelDensFac", OPTIONAL, 0., "");
 
+    /*These parameters are Lyman alpha forest specific*/
     param_declare_double(ps, "QuickLymanAlphaProbability", OPTIONAL, 0, "");
+    param_declare_int(ps, "HeliumHeatOn", OPTIONAL, 0, "");
+    param_declare_double(ps, "HeliumHeatThresh", OPTIONAL, 10, "");
+    param_declare_double(ps, "HeliumHeatAmp", OPTIONAL, 1, "");
+    param_declare_double(ps, "HeliumHeatExp", OPTIONAL, 0, "");
 
 #endif
 
@@ -461,6 +466,10 @@ void read_parameter_file(char *fname)
         All.WindFreeTravelDensFac = param_get_double(ps, "WindFreeTravelDensFac");
 
         All.QuickLymanAlphaProbability = param_get_double(ps, "QuickLymanAlphaProbability");
+        All.HeliumHeatOn = param_get_int(ps, "HeliumHeatOn");
+        All.HeliumHeatThresh = param_get_double(ps, "HeliumHeatThresh");
+        All.HeliumHeatAmp = param_get_double(ps, "HeliumHeatAmp");
+        All.HeliumHeatExp = param_get_double(ps, "HeliumHeatExp");
 
     #endif
 

--- a/test/powerspectrum_test.c
+++ b/test/powerspectrum_test.c
@@ -32,6 +32,14 @@ void message(int ierr, const char * fmt, ...)
     va_end(va);
 }
 
+void endrun(int ierr, const char * fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    printf(fmt, va);
+    va_end(va);
+    exit(1);
+}
 /*End dummies*/
 
 #define NUM_THREADS 4

--- a/timestep.c
+++ b/timestep.c
@@ -32,7 +32,6 @@ void set_global_time(double newtime) {
     All.cf.fac_egy = pow(All.Time, 3 * GAMMA_MINUS1);
     All.cf.hubble = hubble_function(All.Time);
     All.cf.hubble_a2 = All.Time * All.Time * hubble_function(All.Time);
-    All.cf.D1 = GrowthFactor(All.cf.a);
 
 #ifdef LIGHTCONE
     lightcone_set_time(All.cf.a);


### PR DESCRIPTION
Merge the code for lyman alpha forest analyses. This changes the helium photo-heating rate in
an attempt to approximately account for helium reionisation. It allows the temperature and 
density of the IGM to be marginalised over. This is four extra optional parameters, 
which are fairly forest-specific.

Also fix the tests and save a little time in the cosmology.