### PR TITLE
For yufeng: another set of cleanups from me

### DIFF
--- a/accel.c
+++ b/accel.c
@@ -28,8 +28,6 @@
  */
 void compute_accelerations(int mode)
 {
-    int TreeReconstructFlag = 0;
-
     message(0, "Start force computation...\n");
 
     walltime_measure("/Misc");

--- a/allvars.h
+++ b/allvars.h
@@ -382,8 +382,6 @@ extern struct global_data_all_processes
 
     int TypeOfOpeningCriterion;	/*!< determines tree cell-opening criterion: 0 for Barnes-Hut, 1 for relative
                                   criterion */
-    int TypeOfTimestepCriterion;	/*!< gives type of timestep criterion (only 0 supported right now - unlike
-                                      gadget-1.1) */
     int CoolingOn;		/*!< flags that cooling is enabled */
     double UVRedshiftThreshold;		/* Initial redshift of UV background. */
     int HydroOn;		/*!< flags that hydro force is enabled */

--- a/allvars.h
+++ b/allvars.h
@@ -532,11 +532,6 @@ extern struct global_data_all_processes
     int OutputListLength;		/*!< number of times stored in table of desired output times */
 
 
-
-#if defined(ADAPTIVE_GRAVSOFT_FORGAS) && !defined(ADAPTIVE_GRAVSOFT_FORGAS_HSML)
-    double ReferenceGasMass;
-#endif
-
 #ifdef SFR		/* star formation and feedback sector */
     double CritOverDensity;
     double CritPhysDensity;

--- a/allvars.h
+++ b/allvars.h
@@ -393,7 +393,6 @@ extern struct global_data_all_processes
     enum WindModel WindModel;		/*!< flags that star formation is enabled */
 
     int MakeGlassFile; /*!< flags that gravity is reversed and we are making a glass file*/
-    int NoTreeType; /*!< flags a particle species to exclude from tree forces*/
     int FastParticleType; /*!< flags a particle species to exclude timestep calculations.*/
     /* parameters determining output frequency */
 

--- a/domain.c
+++ b/domain.c
@@ -1994,8 +1994,6 @@ void domain_insertnode(struct local_topnode_data *treeA, struct local_topnode_da
 int
 domain_garbage_collection(void)
 {
-    int i;
-
     int tree_invalid = 0;
 
     /* tree is invalidated of the sequence on P is reordered; */
@@ -2032,13 +2030,13 @@ domain_refresh_totals()
 static int
 domain_sph_garbage_collection_reclaim()
 {
-    int i;
     int tree_invalid = 0;
 
     int64_t total0, total;
     sumup_large_ints(1, &N_sph_slots, &total0);
 
 #ifdef SFR
+    int i;
     for(i = 0; i < N_sph_slots; i++) {
         while(P[i].Type != 0 && i < N_sph_slots) {
             /* remove this particle from SphP, because
@@ -2067,7 +2065,7 @@ static int
 domain_all_garbage_collection()
 {
     int i, tree_invalid = 0; 
-    int count_elim, count_gaselim, tot_elim, tot_gaselim;
+    int count_elim, count_gaselim;
     int64_t total0, total;
     int64_t total0_gas, total_gas;
 

--- a/forcetree.c
+++ b/forcetree.c
@@ -55,9 +55,6 @@ static void
 force_treeallocate(int maxnodes, int maxpart);
 
 static void
-force_update_hmax_of_node(int no, int mode);
-
-static void
 force_flag_localnodes(void);
 
 static void

--- a/forcetree.c
+++ b/forcetree.c
@@ -210,10 +210,6 @@ int force_tree_build_single(int npart, struct unbind_data *mp)
         else
             i = k;
 
-        /*We sometimes want to disable the tree for hot particles*/
-        if(P[i].Type == All.NoTreeType)
-            continue;
-
         rep = 0;
 
         key = peano_and_morton_key((int) ((P[i].Pos[0] - DomainCorner[0]) * DomainFac),
@@ -1181,10 +1177,6 @@ void force_kick_node(int i, MyFloat * dv)
 {
     int j, no;
     MyFloat dp[3], v, vmax;
-
-    /*We sometimes want to disable the tree for hot particles*/
-    if(P[i].Type == All.NoTreeType)
-        return;
 
     for(j = 0; j < 3; j++)
     {

--- a/gravpm.c
+++ b/gravpm.c
@@ -135,7 +135,7 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
     }
     /* All particles shall have been processed just once. Otherwise we die */
     if(numpart != NumPart) {
-        endrun(1, "numpart = %d\n", numpart);
+        endrun(1, "Processed only %d particles out of %d\n", numpart, NumPart);
     }
     for(r =0; r < *Nregions; r++) {
         convert_node_to_region(&regions[r]);

--- a/gravshort-tree-old.c
+++ b/gravshort-tree-old.c
@@ -149,7 +149,7 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
         LocalTreeWalk * lv)
 {
     struct NODE *nop = 0;
-    int no, ptype, nexp, tabindex, task, listindex = 0;
+    int no, ptype, tabindex, listindex = 0;
     int nnodesinlist = 0, ninteractions = 0;
     double r2, dx, dy, dz, mass, r, fac, u, h, h_inv, h3_inv;
     double pos_x, pos_y, pos_z, aold;
@@ -175,12 +175,6 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
     double pot;
 
     pot = 0;
-#endif
-#ifdef PERIODIC
-    double boxsize, boxhalf;
-
-    boxsize = All.BoxSize;
-    boxhalf = 0.5 * All.BoxSize;
 #endif
 
 #ifdef DISTORTIONTENSORPS

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -111,7 +111,7 @@ void grav_short_tree(void)
  *  with the Newtonian form. The resulting short-range suppression compared
  *  to the Newtonian force is tabulated, because looking up from this table
  *  is faster than recomputing the corresponding factor, despite the
- *  memory-access panelty (which reduces cache performance) incurred by the
+ *  memory-access penalty (which reduces cache performance) incurred by the
  *  table.
  */
 int force_treeev_shortrange(TreeWalkQueryGravShort * input,

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -119,7 +119,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
         LocalTreeWalk * lv)
 {
     struct NODE *nop = 0;
-    int no, ptype, tabindex, listindex = 0;
+    int no, ptype, listindex = 0;
     int nnodesinlist = 0, ninteractions = 0;
     double r2, dx, dy, dz, mass, r, fac, u, h, h_inv, h3_inv;
     double pos_x, pos_y, pos_z, aold;

--- a/init.c
+++ b/init.c
@@ -178,8 +178,10 @@ setup_smoothinglengths(int RestartSnapNum)
 #pragma omp parallel for
         for(i = 0; i < NumPart; i++)
         {
-            int no, p;
-            no = Father[i];
+            int no = Father[i];
+            /* Don't need smoothing lengths for DM particles*/
+            if(P[i].Type != 0 && P[i].Type != 4 && P[i].Type != 5)
+                continue;
             /* quick hack to adjust for the baryon fraction
              * only this fraction of mass is of that type.
              * this won't work for non-dm non baryon;
@@ -195,7 +197,7 @@ setup_smoothinglengths(int RestartSnapNum)
             }
             while(10 * All.DesNumNgb * P[i].Mass > massfactor * Nodes[no].u.d.mass)
             {
-                p = Nodes[no].u.d.father;
+                int p = Nodes[no].u.d.father;
 
                 if(p < 0)
                     break;

--- a/param.c
+++ b/param.c
@@ -90,6 +90,11 @@ OutputListAction(ParameterSet * ps, char * name, void * data)
     /*Now read in the values*/
     for(count=0,token=strtok(outputlist,","); count < All.OutputListLength && token; count++, token=strtok(NULL,","))
     {
+        /* Skip a leading quote if one exists.
+         * Extra characters are ignored by atof, so
+         * no need to skip matching char.*/
+        if(token[0] == '"')
+            token+=1;
         All.OutputListTimes[count] = atof(token);
 /*         message(1, "Output at: %g\n", All.OutputListTimes[count]); */
     }

--- a/param.c
+++ b/param.c
@@ -155,7 +155,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "MinGasHsmlFractional", OPTIONAL, 0, "");
     param_declare_double(ps, "MaxGasVel", OPTIONAL, 3e5, "");
 
-    param_declare_int(ps,    "TypeOfTimestepCriterion", OPTIONAL, 0, "Magic numbers!");
+    param_declare_int(ps,    "TypeOfTimestepCriterion", OPTIONAL, 0, "Compatibility only. Has no effect");
     param_declare_double(ps, "MaxSizeTimestep", OPTIONAL, 0.1, "");
     param_declare_double(ps, "MinSizeTimestep", OPTIONAL, 0, "");
 
@@ -393,7 +393,6 @@ void read_parameter_file(char *fname)
         All.FastParticleType = param_get_int(ps, "FastParticleType");
         All.NoTreeType = param_get_int(ps, "NoTreeType");
         All.StarformationOn = param_get_int(ps, "StarformationOn");
-        All.TypeOfTimestepCriterion = param_get_int(ps, "TypeOfTimestepCriterion");
         All.TypeOfOpeningCriterion = param_get_int(ps, "TypeOfOpeningCriterion");
         All.TimeLimitCPU = param_get_double(ps, "TimeLimitCPU");
         All.SofteningHalo = param_get_double(ps, "SofteningHalo");
@@ -474,11 +473,6 @@ void read_parameter_file(char *fname)
     #endif
 
         parameter_set_free(ps);
-
-        if(All.TypeOfTimestepCriterion >= 3)
-        {
-            endrun(1, "The specified timestep criterion is not valid\n");
-        }
 
     #ifdef SFR
 

--- a/param.c
+++ b/param.c
@@ -185,7 +185,6 @@ create_gadget_parameter_set()
     param_declare_int(ps, "StarformationOn", REQUIRED, 0, "Enables star formation");
     param_declare_int(ps, "RadiationOn", OPTIONAL, 0, "Include radiation density in the background evolution.");
     param_declare_int(ps, "FastParticleType", OPTIONAL, 2, "Particles of this type will not decrease the timestep. Default neutrinos.");
-    param_declare_int(ps, "NoTreeType", OPTIONAL, 2, "Particles of this type will not produce tree forces. Default neutrinos.");
 
     param_declare_double(ps, "SofteningHalo", REQUIRED, 0, "");
     param_declare_double(ps, "SofteningDisk", REQUIRED, 0, "");
@@ -391,7 +390,6 @@ void read_parameter_file(char *fname)
         All.DensityOn = param_get_int(ps, "DensityOn");
         All.TreeGravOn = param_get_int(ps, "TreeGravOn");
         All.FastParticleType = param_get_int(ps, "FastParticleType");
-        All.NoTreeType = param_get_int(ps, "NoTreeType");
         All.StarformationOn = param_get_int(ps, "StarformationOn");
         All.TypeOfOpeningCriterion = param_get_int(ps, "TypeOfOpeningCriterion");
         All.TimeLimitCPU = param_get_double(ps, "TimeLimitCPU");

--- a/param.c
+++ b/param.c
@@ -207,10 +207,6 @@ create_gadget_parameter_set()
     param_declare_double(ps, "InitGasTemp", REQUIRED, 0, "");
     param_declare_double(ps, "MinGasTemp", REQUIRED, 0, "");
 
-#if defined(ADAPTIVE_GRAVSOFT_FORGAS) && !defined(ADAPTIVE_GRAVSOFT_FORGAS_HSML)
-    param_declare_double(ps, "ReferenceGasMass", REQUIRED, 0, "");
-#endif
-
     param_declare_int(ps, "SnapshotWithFOF", REQUIRED, 0, "Enable Friends-of-Friends halo finder.");
     param_declare_double(ps, "FOFHaloLinkingLength", OPTIONAL, 0.2, "Linking length for Friends of Friends halos.");
     param_declare_int(ps, "FOFHaloMinLength", OPTIONAL, 32, "");
@@ -419,10 +415,6 @@ void read_parameter_file(char *fname)
 
         All.InitGasTemp = param_get_double(ps, "InitGasTemp");
         All.MinGasTemp = param_get_double(ps, "MinGasTemp");
-
-    #if defined(ADAPTIVE_GRAVSOFT_FORGAS) && !defined(ADAPTIVE_GRAVSOFT_FORGAS_HSML)
-        All.ReferenceGasMass = param_get_double(ps, "ReferenceGasMass");
-    #endif
 
         All.SnapshotWithFOF = param_get_int(ps, "SnapshotWithFOF");
         All.FOFHaloLinkingLength = param_get_double(ps, "FOFHaloLinkingLength");

--- a/petaio.c
+++ b/petaio.c
@@ -222,8 +222,6 @@ static void petaio_write_header(BigFile * bf) {
         endrun(0, "Failed to create block at %s:%s\n", "Header",
                 big_file_get_error_message());
     }
-    int i;
-    int k;
 
     if( 
     (0 != big_block_set_attr(&bh, "TotNumPart", NTotal, "u8", 6)) ||

--- a/run.c
+++ b/run.c
@@ -143,7 +143,7 @@ update_IO_params(const char * ioctlfname)
         size_t n = 0;
         char * line = NULL;
         while(-1 != getline(&line, &n, fd)) {
-            sscanf(line, "BytesPerFile %d", &All.IO.BytesPerFile);
+            sscanf(line, "BytesPerFile %lu", &All.IO.BytesPerFile);
             sscanf(line, "NumWriters %d", &All.IO.NumWriters);
         }
         free(line);

--- a/runtests.c
+++ b/runtests.c
@@ -14,6 +14,8 @@
 #include "endrun.h"
 #include "petaio.h"
 
+void grav_short_tree_old(void);
+
 char * GDB_format_particle(int i);
 
 SIMPLE_PROPERTY(GravAccel, P[i].GravAccel[0], float, 3)

--- a/timestep.c
+++ b/timestep.c
@@ -406,15 +406,8 @@ int get_timestep(int p,		/*!< particle index */
             }
             dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] / ac);
 #ifdef ADAPTIVE_GRAVSOFT_FORGAS
-#ifdef ADAPTIVE_GRAVSOFT_FORGAS_HSML
             if(P[p].Type == 0)
                 dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * P[p].Hsml / 2.8 / ac);
-#else
-            if(P[p].Type == 0)
-                dt =
-                    sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] *
-                            pow(P[p].Mass / All.ReferenceGasMass, 1.0 / 3) / ac);
-#endif
 #endif
             break;
 

--- a/timestep.c
+++ b/timestep.c
@@ -390,32 +390,21 @@ int get_timestep(int p,		/*!< particle index */
     if(ac == 0)
         ac = 1.0e-30;
 
-
-    switch (All.TypeOfTimestepCriterion)
+    if(flag > 0)
     {
-        case 0:
-            if(flag > 0)
-            {
-                dt = flag * All.Timebase_interval;
+        dt = flag * All.Timebase_interval;
 
-                dt /= All.cf.hubble;	/* convert dloga to physical timestep  */
+        dt /= All.cf.hubble;	/* convert dloga to physical timestep  */
 
-                ac = 2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] / (dt * dt);
-                *aphys = ac;
-                return flag;
-            }
-            dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] / ac);
-#ifdef ADAPTIVE_GRAVSOFT_FORGAS
-            if(P[p].Type == 0)
-                dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * P[p].Hsml / 2.8 / ac);
-#endif
-            break;
-
-        default:
-            endrun(888, "\n !!!2@@@!!! \n");
-            break;
+        ac = 2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] / (dt * dt);
+        *aphys = ac;
+        return flag;
     }
-
+    dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * All.SofteningTable[P[p].Type] / ac);
+#ifdef ADAPTIVE_GRAVSOFT_FORGAS
+    if(P[p].Type == 0)
+        dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * P[p].Hsml / 2.8 / ac);
+#endif
 
     if(P[p].Type == 0)
     {

--- a/timestep.c
+++ b/timestep.c
@@ -7,6 +7,7 @@
 #include "proto.h"
 #include "forcetree.h"
 #include "cosmology.h"
+#include "cooling.h"
 #include "mymalloc.h"
 #include "endrun.h"
 #include "domain.h"
@@ -36,9 +37,7 @@ void set_global_time(double newtime) {
 #ifdef LIGHTCONE
     lightcone_set_time(All.cf.a);
 #endif
-#ifdef COOL
     IonizeParams();
-#endif
     set_softenings();
 }
 


### PR DESCRIPTION
This set of cleanups:
- Fixes compile warnings
- Fixes a parsing problem I encountered with my parameter files
- Makes TypeOfTimestepCriterion an actual nullop; the parameter is declared for compatibility, but does nothing.
- Fixes an ifdef around the IonizeParams call; without this all hydro sims wil be wrong!
- Removes ADAPTIVE_GRAVSOFT_FORGAS_HSML
- Removes NoTreeType as it is non-functional. Another way to make particle neutrino sims work is pending.
- Avoids computing initial smoothing lengths for DM particles. This was mainly a problem with NoTreeType, which I later removed anyway, but is I think a generally good cleanup.