### PR TITLE
Treewalk any list

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -84,7 +84,7 @@ static void
 blackhole_accretion_postprocess(int n, TreeWalk * tw);
 /* feedback routines. currently also performs the drifting(move it to gravtree / force tree?) */
 static int
-blackhole_accretion_isinteracting(int n, TreeWalk * tw);
+blackhole_accretion_haswork(int n, TreeWalk * tw);
 
 static void
 blackhole_accretion_reduce(int place, TreeWalkResultBHAccretion * remote, enum TreeWalkReduceMode mode, TreeWalk * tw);
@@ -107,7 +107,7 @@ static void
 blackhole_feedback_postprocess(int n, TreeWalk * tw);
 
 static int
-blackhole_feedback_isinteracting(int n, TreeWalk * tw);
+blackhole_feedback_haswork(int n, TreeWalk * tw);
 
 static void
 blackhole_feedback_reduce(int place, TreeWalkResultBHFeedback * remote, enum TreeWalkReduceMode mode, TreeWalk * tw);
@@ -156,7 +156,7 @@ void blackhole(void)
     tw_accretion->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw_accretion->ngbiter_type_elsize = sizeof(TreeWalkNgbIterBHAccretion);
     tw_accretion->ngbiter = (TreeWalkNgbIterFunction) blackhole_accretion_ngbiter;
-    tw_accretion->isinteracting = blackhole_accretion_isinteracting;
+    tw_accretion->haswork = blackhole_accretion_haswork;
     tw_accretion->postprocess = (TreeWalkProcessFunction) blackhole_accretion_postprocess;
     tw_accretion->fill = (TreeWalkFillQueryFunction) blackhole_accretion_copy;
     tw_accretion->reduce = (TreeWalkReduceResultFunction) blackhole_accretion_reduce;
@@ -169,7 +169,7 @@ void blackhole(void)
     tw_feedback->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw_feedback->ngbiter_type_elsize = sizeof(TreeWalkNgbIterBHFeedback);
     tw_feedback->ngbiter = (TreeWalkNgbIterFunction) blackhole_feedback_ngbiter;
-    tw_feedback->isinteracting = blackhole_feedback_isinteracting;
+    tw_feedback->haswork = blackhole_feedback_haswork;
     tw_feedback->fill = (TreeWalkFillQueryFunction) blackhole_feedback_copy;
     tw_feedback->postprocess = (TreeWalkProcessFunction) blackhole_feedback_postprocess;
     tw_feedback->preprocess = (TreeWalkProcessFunction) blackhole_feedback_preprocess;
@@ -615,7 +615,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 }
 
 static int
-blackhole_accretion_isinteracting(int n, TreeWalk * tw)
+blackhole_accretion_haswork(int n, TreeWalk * tw)
 {
     return (P[n].Type == 5) && (P[n].Mass > 0);
 }
@@ -670,7 +670,7 @@ blackhole_accretion_copy(int place, TreeWalkQueryBHAccretion * I, TreeWalk * tw)
 }
 
 static int
-blackhole_feedback_isinteracting(int n, TreeWalk * tw)
+blackhole_feedback_haswork(int n, TreeWalk * tw)
 {
     return (P[n].Type == 5) && (!P[n].Swallowed);
 }

--- a/blackhole.c
+++ b/blackhole.c
@@ -186,12 +186,12 @@ void blackhole(void)
 
     /* Let's determine which particles may be swalled and calculate total feedback weights */
 
-    treewalk_run(tw_accretion);
+    treewalk_run(tw_accretion, ActiveParticle, NumActiveParticle);
 
     message(0, "Start swallowing of gas particles and black holes\n");
 
     /* Now do the swallowing of particles and dump feedback energy */
-    treewalk_run(tw_feedback);
+    treewalk_run(tw_feedback, ActiveParticle, NumActiveParticle);
 
     MPI_Reduce(&N_sph_swallowed, &Ntot_gas_swallowed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&N_BH_swallowed, &Ntot_BH_swallowed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);

--- a/density.c
+++ b/density.c
@@ -70,9 +70,7 @@ density_ngbiter(
 
 static int density_isinteracting(int n, TreeWalk * tw);
 static void density_postprocess(int i, TreeWalk * tw);
-static void density_preprocess(int i, TreeWalk * tw);
 static void density_check_neighbours(int i, TreeWalk * tw);
-
 
 static void density_reduce(int place, TreeWalkResultDensity * remote, enum TreeWalkReduceMode mode, TreeWalk * tw);
 static void density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw);
@@ -114,7 +112,6 @@ void density(void)
     tw->isinteracting = density_isinteracting;
     tw->fill = (TreeWalkFillQueryFunction) density_copy;
     tw->reduce = (TreeWalkReduceResultFunction) density_reduce;
-    tw->preprocess = (TreeWalkProcessFunction) density_preprocess;
     tw->postprocess = (TreeWalkProcessFunction) density_postprocess;
     tw->UseNodeList = 1;
     tw->query_type_elsize = sizeof(TreeWalkQueryDensity);
@@ -143,6 +140,9 @@ void density(void)
     {
         const int p_i = ActiveParticle[i];
         P[p_i].DensityIterationDone = 0;
+        DENSITY_GET_PRIV(tw)->Left[p_i] = 0;
+        DENSITY_GET_PRIV(tw)->Right[p_i] = 0;
+
     }
 
     /* allocate buffers to arrange communication */
@@ -371,13 +371,6 @@ density_isinteracting(int n, TreeWalk * tw)
         return 1;
 
     return 0;
-}
-
-static void
-density_preprocess(int p, TreeWalk * tw)
-{
-    DENSITY_GET_PRIV(tw)->Left[p] = 0;
-    DENSITY_GET_PRIV(tw)->Right[p] = 0;
 }
 
 static void

--- a/density.c
+++ b/density.c
@@ -153,7 +153,7 @@ void density(void)
     do {
         DENSITY_GET_PRIV(tw)->NPLeft = 0;
 
-        treewalk_run(tw);
+        treewalk_run(tw, ActiveParticle, NumActiveParticle);
         sumup_large_ints(1, &DENSITY_GET_PRIV(tw)->NPLeft, &ntot);
 
         if(ntot == 0) break;

--- a/density.c
+++ b/density.c
@@ -68,7 +68,7 @@ density_ngbiter(
         TreeWalkNgbIterDensity * iter,
         LocalTreeWalk * lv);
 
-static int density_isinteracting(int n, TreeWalk * tw);
+static int density_haswork(int n, TreeWalk * tw);
 static void density_postprocess(int i, TreeWalk * tw);
 static void density_check_neighbours(int i, TreeWalk * tw);
 
@@ -109,7 +109,7 @@ void density(void)
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterDensity);
     tw->ngbiter = (TreeWalkNgbIterFunction) density_ngbiter;
-    tw->isinteracting = density_isinteracting;
+    tw->haswork = density_haswork;
     tw->fill = (TreeWalkFillQueryFunction) density_copy;
     tw->reduce = (TreeWalkReduceResultFunction) density_reduce;
     tw->postprocess = (TreeWalkProcessFunction) density_postprocess;
@@ -163,7 +163,7 @@ void density(void)
         if(ntot < 1 ) {
             foreach(ActiveParticle)
             {
-                if(density_isinteracting(i) && !P[i].DensityIterationDone) {
+                if(density_haswork(i) && !P[i].DensityIterationDone) {
                     message
                         (1, "i=%d task=%d ID=%llu type=%d, Hsml=%g DENSITY_GET_PRIV(tw)->Left=%g DENSITY_GET_PRIV(tw)->Right=%g Ngbs=%g DENSITY_GET_PRIV(tw)->Right-DENSITY_GET_PRIV(tw)->Left=%g\n   pos=(%g|%g|%g)\n",
                          i, ThisTask, P[i].ID, P[i].Type, P[i].Hsml, DENSITY_GET_PRIV(tw)->Left[i], DENSITY_GET_PRIV(tw)->Right[i],
@@ -359,7 +359,7 @@ density_ngbiter(
 }
 
 static int
-density_isinteracting(int n, TreeWalk * tw)
+density_haswork(int n, TreeWalk * tw)
 {
     if(P[n].DensityIterationDone) return 0;
 

--- a/endrun.c
+++ b/endrun.c
@@ -5,6 +5,14 @@
 
 #include "endrun.h"
 
+/* Watch out:
+ *
+ * On some versions of OpenMPI with CPU frequency scaling we see negative time
+ * due to a bug in OpenMPI https://github.com/open-mpi/ompi/issues/3003
+ *
+ * But they have fixed it.
+ */
+
 static double _timestart = -1;
 /*  This function aborts the simulation.
  *

--- a/endrun.h
+++ b/endrun.h
@@ -1,4 +1,3 @@
 
-
 void endrun(int, const char * fmt, ...);
 void message(int, const char * fmt, ...);

--- a/fof.c
+++ b/fof.c
@@ -330,7 +330,7 @@ void fof_label_primary(void)
     {
         t0 = second();
 
-        treewalk_run(tw);
+        treewalk_run(tw, NULL, -1);
 
         t1 = second();
 
@@ -1087,7 +1087,7 @@ static void fof_label_secondary(void)
         FOF_SECONDARY_GET_PRIV(tw)->npleft = 0;
         FOF_SECONDARY_GET_PRIV(tw)->count = 0;
 
-        treewalk_run(tw);
+        treewalk_run(tw, NULL, -1);
 
         sumup_large_ints(1, &FOF_SECONDARY_GET_PRIV(tw)->npleft, &ntot);
         sumup_large_ints(1, &FOF_SECONDARY_GET_PRIV(tw)->count, &counttot);

--- a/fof.c
+++ b/fof.c
@@ -111,9 +111,6 @@ static struct fof_particle_list
 }
 *HaloLabel;
 
-static float *fof_secondary_distance;
-static float *fof_secondary_hsml;
-
 static MPI_Datatype MPI_TYPE_GROUP;
 
 void fof_fof(int num)
@@ -212,63 +209,72 @@ void fof_fof(int num)
     MPI_Type_free(&MPI_TYPE_GROUP);
 }
 
-static MyIDType * FOFOldMinID;
-static char * FOFPrimaryActive;
-static int * FOFHead;
+struct FOFPrimaryPriv {
+    int * Head;
+    char * PrimaryActive;
+    MyIDType * OldMinID;
+};
+#define FOF_PRIMARY_GET_PRIV(tw) ((struct FOFPrimaryPriv *) (tw->priv))
 
-static int HEADl(int stop, int i) {
+static int
+HEADl(int stop, int i, TreeWalk * tw)
+{
     int r;
     if (i == stop) {
         return -1;
     }
 //    printf("locking %d by %d in HEADl stop = %d\n", i, omp_get_thread_num(), stop);
     lock_particle(i);
-//    printf("locked %d by %d in HEADl, next = %d\n", i, omp_get_thread_num(), FOFHead[i]);
+//    printf("locked %d by %d in HEADl, next = %d\n", i, omp_get_thread_num(), FOF_PRIMARY_GET_PRIV(tw)->Head[i]);
 
-    if(FOFHead[i] == i) {
+    if(FOF_PRIMARY_GET_PRIV(tw)->Head[i] == i) {
         /* return locked */
         return i;
     }
     /* this is not the root, keep going, but unlock first, since even if the root is modified by
      * another thread, what we get here is on the path, */
-    int next = FOFHead[i];
+    int next = FOF_PRIMARY_GET_PRIV(tw)->Head[i];
     unlock_particle(i);
 //    printf("unlocking %d by %d in HEADl\n", i, omp_get_thread_num());
-    r = HEADl(stop, next);
+    r = HEADl(stop, next, tw);
     return r;
 }
-static void update_root(int i, int r)
+
+static void
+update_root(int i, int r, TreeWalk * tw)
 {
-    while(FOFHead[i] != i) {
-        int t = FOFHead[i];
-        FOFHead[i]= r;
+    while(FOF_PRIMARY_GET_PRIV(tw)->Head[i] != i) {
+        int t = FOF_PRIMARY_GET_PRIV(tw)->Head[i];
+        FOF_PRIMARY_GET_PRIV(tw)->Head[i]= r;
         i = t;
     }
 }
 
-static int HEAD(int i) {
+static int
+HEAD(int i, TreeWalk * tw)
+{
     /* accelerate with a splay: see https://arxiv.org/abs/1607.03224 */
     int r;
     r = i;
-    while(FOFHead[r] != r) {
-        r = FOFHead[r];
+    while(FOF_PRIMARY_GET_PRIV(tw)->Head[r] != r) {
+        r = FOF_PRIMARY_GET_PRIV(tw)->Head[r];
     }
-    while(FOFHead[i] != i) {
-        int t = FOFHead[i];
-        FOFHead[i]= r;
+    while(FOF_PRIMARY_GET_PRIV(tw)->Head[i] != i) {
+        int t = FOF_PRIMARY_GET_PRIV(tw)->Head[i];
+        FOF_PRIMARY_GET_PRIV(tw)->Head[i]= r;
         i = t;
     }
     return r;
 }
 
 static void fof_primary_copy(int place, TreeWalkQueryFOF * I, TreeWalk * tw) {
-    int head = HEAD(place);
+    int head = HEAD(place, tw);
     I->MinID = HaloLabel[head].MinID;
     I->MinIDTask = HaloLabel[head].MinIDTask;
 }
 
 static int fof_primary_isinteracting(int n, TreeWalk * tw) {
-    return (((1 << P[n].Type) & (FOF_PRIMARY_LINK_TYPES))) && FOFPrimaryActive[n];
+    return (((1 << P[n].Type) & (FOF_PRIMARY_LINK_TYPES))) && FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[n];
 }
 
 static void
@@ -299,10 +305,12 @@ void fof_label_primary(void)
     tw->type = TREEWALK_ALL;
     tw->query_type_elsize = sizeof(TreeWalkQueryFOF);
     tw->result_type_elsize = sizeof(TreeWalkResultFOF);
+    struct FOFPrimaryPriv priv[1];
+    tw->priv = priv;
 
-    FOFHead = (int*) mymalloc("FOF_Links", NumPart * sizeof(int));
-    FOFPrimaryActive = (char*) mymalloc("FOFActive", NumPart * sizeof(char));
-    FOFOldMinID = (MyIDType *) mymalloc("FOFActive", NumPart * sizeof(MyIDType));
+    FOF_PRIMARY_GET_PRIV(tw)->Head = (int*) mymalloc("FOF_Links", NumPart * sizeof(int));
+    FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive = (char*) mymalloc("FOFActive", NumPart * sizeof(char));
+    FOF_PRIMARY_GET_PRIV(tw)->OldMinID = (MyIDType *) mymalloc("FOFActive", NumPart * sizeof(MyIDType));
 
     /* allocate buffers to arrange communication */
 
@@ -310,9 +318,9 @@ void fof_label_primary(void)
 
     for(i = 0; i < NumPart; i++)
     {
-        FOFHead[i] = i;
-        FOFOldMinID[i]= P[i].ID;
-        FOFPrimaryActive[i] = 1;
+        FOF_PRIMARY_GET_PRIV(tw)->Head[i] = i;
+        FOF_PRIMARY_GET_PRIV(tw)->OldMinID[i]= P[i].ID;
+        FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[i] = 1;
 
         HaloLabel[i].MinID = P[i].ID;
         HaloLabel[i].MinIDTask = ThisTask;
@@ -331,15 +339,15 @@ void fof_label_primary(void)
         link_across = 0;
 #pragma omp parallel for
         for(i = 0; i < NumPart; i++) {
-            MyIDType newMinID = HaloLabel[HEAD(i)].MinID;
-            if(newMinID != FOFOldMinID[i]) {
-                FOFPrimaryActive[i] = 1;
+            MyIDType newMinID = HaloLabel[HEAD(i, tw)].MinID;
+            if(newMinID != FOF_PRIMARY_GET_PRIV(tw)->OldMinID[i]) {
+                FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[i] = 1;
 #pragma omp atomic
                 link_across += 1;
             } else {
-                FOFPrimaryActive[i] = 0;
+                FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[i] = 0;
             }
-            FOFOldMinID[i] = newMinID;
+            FOF_PRIMARY_GET_PRIV(tw)->OldMinID[i] = newMinID;
         }
         MPI_Allreduce(&link_across, &link_across_tot, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
         message(0, "Linked %ld particles %g seconds\n", link_across_tot, t1 - t0);
@@ -349,36 +357,37 @@ void fof_label_primary(void)
     /* Update MinID of all linked (primary-linked) particles */
     for(i = 0; i < NumPart; i++)
     {
-        HaloLabel[i].MinID = HaloLabel[HEAD(i)].MinID;
-        HaloLabel[i].MinIDTask = HaloLabel[HEAD(i)].MinIDTask;
+        HaloLabel[i].MinID = HaloLabel[HEAD(i, tw)].MinID;
+        HaloLabel[i].MinIDTask = HaloLabel[HEAD(i, tw)].MinIDTask;
     }
 
     message(0, "Local groups found.\n");
 
-    myfree(FOFOldMinID);
-    myfree(FOFPrimaryActive);
-    myfree(FOFHead);
+    myfree(FOF_PRIMARY_GET_PRIV(tw)->OldMinID);
+    myfree(FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive);
+    myfree(FOF_PRIMARY_GET_PRIV(tw)->Head);
 }
 
-static void fofp_merge(int target, int other)
+static void
+fofp_merge(int target, int other, TreeWalk * tw)
 {
     /* this will lock h1 */
-    int h1 = HEADl(-1, target);
+    int h1 = HEADl(-1, target, tw);
     /* stop looking if we find h1 along the path (because it is already owned by us) */
-    int h2 = HEADl(h1, other);
+    int h2 = HEADl(h1, other, tw);
 
     if(h2 == -1) {
         /* h1 is along the path of h2, already merged.  **/
         /* h1 must be the root of other and target both */
         //printf("unlocking %d by %d in merge\n", h1, omp_get_thread_num());
-        update_root(target, h1);
-        update_root(other, h1);
+        update_root(target, h1, tw);
+        update_root(other, h1, tw);
         unlock_particle(h1);
         return;
     }
 
     /* h2 as a sub-tree of h1 */
-    FOFHead[h2] = h1;
+    FOF_PRIMARY_GET_PRIV(tw)->Head[h2] = h1;
 
     /* update MinID of h1 */
     if(HaloLabel[h1].MinID > HaloLabel[h2].MinID)
@@ -389,8 +398,8 @@ static void fofp_merge(int target, int other)
     //printf("unlocking %d by %d in merge\n", h2, omp_get_thread_num());
     unlock_particle(h2);
 
-    update_root(target, h1);
-    update_root(other, h1);
+    update_root(target, h1, tw);
+    update_root(other, h1, tw);
 
     //printf("unlocking %d by %d in merge\n", h1, omp_get_thread_num());
     unlock_particle(h1);
@@ -402,6 +411,7 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
         TreeWalkNgbIterFOF * iter,
         LocalTreeWalk * lv)
 {
+    TreeWalk * tw = lv->tw;
     if(iter->base.other == -1) {
         iter->base.Hsml = All.FOFHaloComovingLinkingLength;
         iter->base.symmetric = NGB_TREEFIND_ASYMMETRIC;
@@ -416,16 +426,16 @@ fof_primary_ngbiter(TreeWalkQueryFOF * I,
             /* Local FOF */
             if(lv->target <= other) {
                 // printf("locked merge %d %d by %d\n", lv->target, other, omp_get_thread_num());
-                fofp_merge(lv->target, other);
+                fofp_merge(lv->target, other, tw);
             }
         } else /* mode is 1, target is a ghost */
         {
 //            printf("locking %d by %d in ngbiter\n", other, omp_get_thread_num());
             lock_particle(other);
-            if(HaloLabel[HEAD(other)].MinID > I->MinID)
+            if(HaloLabel[HEAD(other, tw)].MinID > I->MinID)
             {
-                HaloLabel[HEAD(other)].MinID = I->MinID;
-                HaloLabel[HEAD(other)].MinIDTask = I->MinIDTask;
+                HaloLabel[HEAD(other, tw)].MinID = I->MinID;
+                HaloLabel[HEAD(other, tw)].MinIDTask = I->MinIDTask;
             }
 //            printf("unlocking %d by %d in ngbiter\n", other, omp_get_thread_num());
             unlock_particle(other);
@@ -966,16 +976,27 @@ void fof_save_groups(int num)
     message(0, "Group catalogues saved. took = %g sec\n", timediff(t0, t1));
 }
 
+/* FIXME: these shall goto the private member of secondary tree walk */
+struct FOFSecondaryPriv {
+    float *distance;
+    float *hsml;
+    int count;
+    int npleft;
+};
+
+#define FOF_SECONDARY_GET_PRIV(tw) ((struct FOFSecondaryPriv *) (tw->priv))
+
 static void fof_secondary_copy(int place, TreeWalkQueryFOF * I, TreeWalk * tw) {
-    I->Hsml = fof_secondary_hsml[place];
+
+    I->Hsml = FOF_SECONDARY_GET_PRIV(tw)->hsml[place];
 }
 static int fof_secondary_isinteracting(int n, TreeWalk * tw) {
     return (((1 << P[n].Type) & (FOF_SECONDARY_LINK_TYPES)));
 }
 static void fof_secondary_reduce(int place, TreeWalkResultFOF * O, enum TreeWalkReduceMode mode, TreeWalk * tw) {
-    if(O->Distance < fof_secondary_distance[place])
+    if(O->Distance < FOF_SECONDARY_GET_PRIV(tw)->distance[place])
     {
-        fof_secondary_distance[place] = O->Distance;
+        FOF_SECONDARY_GET_PRIV(tw)->distance[place] = O->Distance;
         HaloLabel[place].MinID = O->MinID;
         HaloLabel[place].MinIDTask = O->MinIDTask;
     }
@@ -986,10 +1007,34 @@ fof_secondary_ngbiter(TreeWalkQueryFOF * I,
         TreeWalkNgbIterFOF * iter,
         LocalTreeWalk * lv);
 
+static void
+fof_secondary_postprocess(int p, TreeWalk * tw)
+{
+    FOF_SECONDARY_GET_PRIV(tw)->count ++;
+    if(FOF_SECONDARY_GET_PRIV(tw)->distance[p] > 0.5 * LARGE)
+    {
+        if(FOF_SECONDARY_GET_PRIV(tw)->hsml[p] < 4 * All.FOFHaloComovingLinkingLength)  /* we only search out to a maximum distance */
+        {
+            /* need to redo this particle */
+            FOF_SECONDARY_GET_PRIV(tw)->npleft++;
+            FOF_SECONDARY_GET_PRIV(tw)->hsml[p] *= 2.0;
+/*
+            if(iter >= MAXITER - 10)
+            {
+                endrun(1, "i=%d task=%d ID=%llu Hsml=%g  pos=(%g|%g|%g)\n",
+                        p, ThisTask, P[p].ID, FOF_SECONDARY_GET_PRIV(tw)->hsml[p],
+                        P[p].Pos[0], P[p].Pos[1], P[p].Pos[2]);
+            }
+*/
+        } else {
+            FOF_SECONDARY_GET_PRIV(tw)->distance[p] = 0;  /* we not continue to search for this particle */
+        }
+    }
+}
 static void fof_label_secondary(void)
 {
     int i, n, iter;
-    int64_t ntot;
+
     TreeWalk tw[1] = {0};
     tw->ev_label = "FOF_FIND_NEAREST";
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
@@ -998,77 +1043,51 @@ static void fof_label_secondary(void)
     tw->isinteracting = fof_secondary_isinteracting;
     tw->fill = (TreeWalkFillQueryFunction) fof_secondary_copy;
     tw->reduce = (TreeWalkReduceResultFunction) fof_secondary_reduce;
+    tw->postprocess = (TreeWalkProcessFunction) fof_secondary_postprocess;
     tw->UseNodeList = 1;
     tw->type = TREEWALK_ALL;
     tw->query_type_elsize = sizeof(TreeWalkQueryFOF);
     tw->result_type_elsize = sizeof(TreeWalkResultFOF);
+    struct FOFSecondaryPriv priv[1];
+
+    tw->priv = priv;
 
     message(0, "Start finding nearest dm-particle (presently allocated=%g MB)\n",
             AllocatedBytes / (1024.0 * 1024.0));
 
-    fof_secondary_distance = (float *) mymalloc("fof_secondary_distance", sizeof(float) * NumPart);
-    fof_secondary_hsml = (float *) mymalloc("fof_secondary_hsml", sizeof(float) * NumPart);
+    FOF_SECONDARY_GET_PRIV(tw)->distance = (float *) mymalloc("FOF_SECONDARY->distance", sizeof(float) * NumPart);
+    FOF_SECONDARY_GET_PRIV(tw)->hsml = (float *) mymalloc("FOF_SECONDARY->hsml", sizeof(float) * NumPart);
 
     for(n = 0; n < NumPart; n++)
     {
         if(((1 << P[n].Type) & (FOF_SECONDARY_LINK_TYPES)))
         {
-            fof_secondary_distance[n] = LARGE;
+            FOF_SECONDARY_GET_PRIV(tw)->distance[n] = LARGE;
             if(P[n].Type == 0) {
                 /* use gas sml as a hint (faster convergence than 0.1 All.FOFHaloComovingLinkingLength at high-z */
-                fof_secondary_hsml[n] = 0.5 * P[n].Hsml;
+                FOF_SECONDARY_GET_PRIV(tw)->hsml[n] = 0.5 * P[n].Hsml;
             } else {
-                fof_secondary_hsml[n] = 0.1 * All.FOFHaloComovingLinkingLength;
+                FOF_SECONDARY_GET_PRIV(tw)->hsml[n] = 0.1 * All.FOFHaloComovingLinkingLength;
             }
         }
     }
 
-    /* allocate buffers to arrange communication */
-
     iter = 0;
+    int64_t counttot, ntot;
+
     /* we will repeat the whole thing for those particles where we didn't find enough neighbours */
 
     message(0, "fof-nearest iteration started\n");
 
     do 
     {
+        FOF_SECONDARY_GET_PRIV(tw)->npleft = 0;
+        FOF_SECONDARY_GET_PRIV(tw)->count = 0;
+
         treewalk_run(tw);
 
-        int queuesize;
-        int * queue = treewalk_get_queue(tw, &queuesize);
-
-        /* do final operations on results */
-        int npleft = 0;
-        int count = 0;
-        int64_t counttot = 0;
-/* CRAY cc doesn't do this one right */
-//#pragma omp parallel for reduction(+: npleft)
-        for(i = 0; i < queuesize; i++)
-        {
-            int p = queue[i];
-            count ++;
-            if(fof_secondary_distance[p] > 0.5 * LARGE)
-            {
-                if(fof_secondary_hsml[p] < 4 * All.FOFHaloComovingLinkingLength)  /* we only search out to a maximum distance */
-                {
-                    /* need to redo this particle */
-                    npleft++;
-                    fof_secondary_hsml[p] *= 2.0;
-/*
-                    if(iter >= MAXITER - 10)
-                    {
-                        endrun(1, "i=%d task=%d ID=%llu Hsml=%g  pos=(%g|%g|%g)\n",
-                                p, ThisTask, P[p].ID, fof_secondary_hsml[p],
-                                P[p].Pos[0], P[p].Pos[1], P[p].Pos[2]);
-                    }
-*/
-                } else {
-                    fof_secondary_distance[p] = 0;  /* we not continue to search for this particle */
-                }
-            }
-        }
-        sumup_large_ints(1, &npleft, &ntot);
-        sumup_large_ints(1, &count, &counttot);
+        sumup_large_ints(1, &FOF_SECONDARY_GET_PRIV(tw)->npleft, &ntot);
+        sumup_large_ints(1, &FOF_SECONDARY_GET_PRIV(tw)->count, &counttot);
 
         message(0, "fof-nearest iteration %d: need to repeat for %010ld /%010ld particles.\n", iter, ntot, counttot);
 
@@ -1081,12 +1100,11 @@ static void fof_label_secondary(void)
                 endrun(1159, "Failed to converge in fof-nearest");
             }
         }
-        myfree(queue);
     }
     while(ntot > 0);
 
-    myfree(fof_secondary_hsml);
-    myfree(fof_secondary_distance);
+    myfree(FOF_SECONDARY_GET_PRIV(tw)->hsml);
+    myfree(FOF_SECONDARY_GET_PRIV(tw)->distance);
 
     message(0, "done finding nearest dm-particle\n");
 }

--- a/fof.c
+++ b/fof.c
@@ -273,7 +273,7 @@ static void fof_primary_copy(int place, TreeWalkQueryFOF * I, TreeWalk * tw) {
     I->MinIDTask = HaloLabel[head].MinIDTask;
 }
 
-static int fof_primary_isinteracting(int n, TreeWalk * tw) {
+static int fof_primary_haswork(int n, TreeWalk * tw) {
     return (((1 << P[n].Type) & (FOF_PRIMARY_LINK_TYPES))) && FOF_PRIMARY_GET_PRIV(tw)->PrimaryActive[n];
 }
 
@@ -298,7 +298,7 @@ void fof_label_primary(void)
     tw->ngbiter = (TreeWalkNgbIterFunction) fof_primary_ngbiter;
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterFOF);
 
-    tw->isinteracting = fof_primary_isinteracting;
+    tw->haswork = fof_primary_haswork;
     tw->fill = (TreeWalkFillQueryFunction) fof_primary_copy;
     tw->reduce = NULL;
     tw->UseNodeList = 1;
@@ -990,7 +990,7 @@ static void fof_secondary_copy(int place, TreeWalkQueryFOF * I, TreeWalk * tw) {
 
     I->Hsml = FOF_SECONDARY_GET_PRIV(tw)->hsml[place];
 }
-static int fof_secondary_isinteracting(int n, TreeWalk * tw) {
+static int fof_secondary_haswork(int n, TreeWalk * tw) {
     return (((1 << P[n].Type) & (FOF_SECONDARY_LINK_TYPES)));
 }
 static void fof_secondary_reduce(int place, TreeWalkResultFOF * O, enum TreeWalkReduceMode mode, TreeWalk * tw) {
@@ -1043,7 +1043,7 @@ static void fof_label_secondary(void)
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw->ngbiter = (TreeWalkNgbIterFunction) fof_secondary_ngbiter;
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterFOF);
-    tw->isinteracting = fof_secondary_isinteracting;
+    tw->haswork = fof_secondary_haswork;
     tw->fill = (TreeWalkFillQueryFunction) fof_secondary_copy;
     tw->reduce = (TreeWalkReduceResultFunction) fof_secondary_reduce;
     tw->postprocess = (TreeWalkProcessFunction) fof_secondary_postprocess;

--- a/fof.c
+++ b/fof.c
@@ -1010,12 +1010,15 @@ fof_secondary_ngbiter(TreeWalkQueryFOF * I,
 static void
 fof_secondary_postprocess(int p, TreeWalk * tw)
 {
+#pragma omp atomic
     FOF_SECONDARY_GET_PRIV(tw)->count ++;
+
     if(FOF_SECONDARY_GET_PRIV(tw)->distance[p] > 0.5 * LARGE)
     {
         if(FOF_SECONDARY_GET_PRIV(tw)->hsml[p] < 4 * All.FOFHaloComovingLinkingLength)  /* we only search out to a maximum distance */
         {
             /* need to redo this particle */
+#pragma omp atomic
             FOF_SECONDARY_GET_PRIV(tw)->npleft++;
             FOF_SECONDARY_GET_PRIV(tw)->hsml[p] *= 2.0;
 /*

--- a/gravshort-pair.c
+++ b/gravshort-pair.c
@@ -31,7 +31,7 @@ void grav_short_pair(void)
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterGravShort);
     tw->ngbiter = (TreeWalkNgbIterFunction) grav_short_pair_ngbiter;
 
-    tw->isinteracting = grav_short_isinteracting;
+    tw->haswork = grav_short_haswork;
     tw->fill = (TreeWalkFillQueryFunction) grav_short_copy;
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;

--- a/gravshort-pair.c
+++ b/gravshort-pair.c
@@ -9,6 +9,7 @@
 #include "cooling.h"
 #include "densitykernel.h"
 #include "treewalk.h"
+#include "timestep.h"
 #include "mymalloc.h"
 #include "endrun.h"
 #include "gravshort.h"
@@ -41,7 +42,7 @@ void grav_short_pair(void)
 
     walltime_measure("/Misc");
 
-    treewalk_run(tw);
+    treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     walltime_measure("/Grav/Short");
 }

--- a/gravshort-tree-old.c
+++ b/gravshort-tree-old.c
@@ -79,7 +79,7 @@ void grav_short_tree_old(void)
 
     tw->ev_label = "FORCETREE_SHORTRANGE";
     tw->visit = (TreeWalkVisitFunction) force_treeevaluate_shortrange;
-    tw->isinteracting = grav_short_isinteracting;
+    tw->haswork = grav_short_haswork;
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;
     tw->UseNodeList = 1;

--- a/gravshort-tree-old.c
+++ b/gravshort-tree-old.c
@@ -11,6 +11,7 @@
 #include "drift.h"
 #include "forcetree.h"
 #include "treewalk.h"
+#include "timestep.h"
 #include "mymalloc.h"
 #include "domain.h"
 #include "endrun.h"
@@ -95,7 +96,7 @@ void grav_short_tree_old(void)
 
     walltime_measure("/Misc");
 
-    treewalk_run(tw);
+    treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     if(All.TypeOfOpeningCriterion == 1) {
         /* This will switch to the relative opening criterion for the following force computations */

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -11,6 +11,7 @@
 #include "forcetree.h"
 #include "treewalk.h"
 #include "mymalloc.h"
+#include "timestep.h"
 #include "endrun.h"
 
 #include "gravshort.h"
@@ -68,7 +69,7 @@ void grav_short_tree(void)
 
     walltime_measure("/Misc");
 
-    treewalk_run(tw);
+    treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     if(All.TypeOfOpeningCriterion == 1) {
         /* This will switch to the relative opening criterion for the following force computations */

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -52,7 +52,7 @@ void grav_short_tree(void)
 
     tw->ev_label = "FORCETREE_SHORTRANGE";
     tw->visit = (TreeWalkVisitFunction) force_treeev_shortrange;
-    tw->isinteracting = grav_short_isinteracting;
+    tw->haswork = grav_short_haswork;
     tw->reduce = (TreeWalkReduceResultFunction) grav_short_reduce;
     tw->postprocess = (TreeWalkProcessFunction) grav_short_postprocess;
     tw->UseNodeList = 1;

--- a/gravshort.h
+++ b/gravshort.h
@@ -21,12 +21,12 @@ typedef struct {
 } TreeWalkResultGravShort;
 
 static int
-grav_short_isinteracting(int i, TreeWalk * tw)
+grav_short_haswork(int i, TreeWalk * tw)
 {
-    int isinteracting = 1;
+    int haswork = 1;
     /* tracer particles (5) has no gravity, they move along to pot minimium */
-    isinteracting = isinteracting && (P[i].Type != 5);
-    return isinteracting;
+    haswork = haswork && (P[i].Type != 5);
+    return haswork;
 }
 
 static void

--- a/hydra.c
+++ b/hydra.c
@@ -108,7 +108,7 @@ void hydro_force(void)
 
     walltime_measure("/SPH/Hydro/Init");
 
-    treewalk_run(tw);
+    treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     /* collect some timing information */
 

--- a/hydra.c
+++ b/hydra.c
@@ -58,7 +58,7 @@ typedef struct {
 } TreeWalkNgbIterHydro;
 
 static int
-hydro_isinteracting(int n, TreeWalk * tw);
+hydro_haswork(int n, TreeWalk * tw);
 
 static void
 hydro_postprocess(int i, TreeWalk * tw);
@@ -91,7 +91,7 @@ void hydro_force(void)
     tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
     tw->ngbiter = (TreeWalkNgbIterFunction) hydro_ngbiter;
     tw->ngbiter_type_elsize = sizeof(TreeWalkNgbIterHydro);
-    tw->isinteracting = hydro_isinteracting;
+    tw->haswork = hydro_haswork;
     tw->fill = (TreeWalkFillQueryFunction) hydro_copy;
     tw->reduce = (TreeWalkReduceResultFunction) hydro_reduce;
     tw->postprocess = (TreeWalkProcessFunction) hydro_postprocess;
@@ -355,7 +355,7 @@ hydro_ngbiter(
 }
 
 static int
-hydro_isinteracting(int i, TreeWalk * tw)
+hydro_haswork(int i, TreeWalk * tw)
 {
     return P[i].Type == 0;
 }

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -108,10 +108,10 @@ static int
 make_particle_wind(MyIDType ID, int i, double v, double vmean[3]);
 
 static int
-sfr_wind_weight_isinteracting(int target, TreeWalk * tw);
+sfr_wind_weight_haswork(int target, TreeWalk * tw);
 
 static int
-sfr_wind_feedback_isinteracting(int target, TreeWalk * tw);
+sfr_wind_feedback_haswork(int target, TreeWalk * tw);
 
 static void
 sfr_wind_reduce_weight(int place, TreeWalkResultWind * remote, enum TreeWalkReduceMode mode, TreeWalk * tw);
@@ -138,7 +138,7 @@ sfr_wind_feedback_ngbiter(TreeWalkQueryWind * I,
  */
 
 static int
-sfr_cooling_isinteracting(int target, TreeWalk * tw)
+sfr_cooling_haswork(int target, TreeWalk * tw)
 {
     return P[target].Type == 0 && P[target].Mass > 0;
 }
@@ -255,7 +255,7 @@ void cooling_and_starformation(void)
 
     tw->visit = NULL; /* no tree walk */
     tw->ev_label = "SFR_COOL";
-    tw->isinteracting = sfr_cooling_isinteracting;
+    tw->haswork = sfr_cooling_haswork;
     tw->postprocess = (TreeWalkProcessFunction) sfr_cool_postprocess;
 
     treewalk_run(tw);
@@ -328,11 +328,11 @@ void cooling_and_starformation(void)
         /* Watchout: the process function name is preprocess, but not called in the feedback tree walk
          * because we need to compute the normalization before the feedback . */
         tw->visit = NULL;
-        tw->isinteracting = (TreeWalkIsInteractingFunction) sfr_wind_feedback_isinteracting;
+        tw->haswork = (TreeWalkHasWorkFunction) sfr_wind_feedback_haswork;
         tw->postprocess = (TreeWalkProcessFunction) sfr_wind_feedback_preprocess; 
         treewalk_run(tw);
 
-        tw->isinteracting = sfr_wind_weight_isinteracting;
+        tw->haswork = sfr_wind_weight_haswork;
         tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
         tw->postprocess = (TreeWalkProcessFunction) sfr_wind_weight_postprocess;
 
@@ -348,7 +348,7 @@ void cooling_and_starformation(void)
         }
 
         /* Then run feedback */
-        tw->isinteracting = (TreeWalkIsInteractingFunction) sfr_wind_feedback_isinteracting;
+        tw->haswork = (TreeWalkHasWorkFunction) sfr_wind_feedback_haswork;
         tw->ngbiter = (TreeWalkNgbIterFunction) sfr_wind_feedback_ngbiter;
         tw->postprocess = (TreeWalkProcessFunction) sfr_wind_feedback_postprocess;
         tw->reduce = NULL;
@@ -381,7 +381,7 @@ void cooling_only(void)
 
     tw->visit = NULL; /* no tree walk */
     tw->ev_label = "SFR_COOL";
-    tw->isinteracting = sfr_cooling_isinteracting;
+    tw->haswork = sfr_cooling_haswork;
     tw->postprocess = (TreeWalkProcessFunction) cool_postprocess;
 
     treewalk_run(tw);
@@ -493,7 +493,7 @@ static int get_sfr_condition(int i) {
 
 #ifdef WINDS
 static int
-sfr_wind_weight_isinteracting(int target, TreeWalk * tw)
+sfr_wind_weight_haswork(int target, TreeWalk * tw)
 {
     if(P[target].Type == 4) {
         if(P[target].IsNewParticle && !P[target].DensityIterationDone) {
@@ -504,7 +504,7 @@ sfr_wind_weight_isinteracting(int target, TreeWalk * tw)
 }
 
 static int
-sfr_wind_feedback_isinteracting(int target, TreeWalk * tw)
+sfr_wind_feedback_haswork(int target, TreeWalk * tw)
 {
     if(P[target].Type == 4) {
         if(P[target].IsNewParticle) {

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -258,7 +258,7 @@ void cooling_and_starformation(void)
     tw->haswork = sfr_cooling_haswork;
     tw->postprocess = (TreeWalkProcessFunction) sfr_cool_postprocess;
 
-    treewalk_run(tw);
+    treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     int tot_spawned, tot_converted;
     MPI_Allreduce(&stars_spawned, &tot_spawned, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
@@ -330,7 +330,7 @@ void cooling_and_starformation(void)
         tw->visit = NULL;
         tw->haswork = (TreeWalkHasWorkFunction) sfr_wind_feedback_haswork;
         tw->postprocess = (TreeWalkProcessFunction) sfr_wind_feedback_preprocess; 
-        treewalk_run(tw);
+        treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
         tw->haswork = sfr_wind_weight_haswork;
         tw->visit = (TreeWalkVisitFunction) treewalk_visit_ngbiter;
@@ -339,7 +339,7 @@ void cooling_and_starformation(void)
         int done = 0;
         while(!done) {
             NPLeft = 0;
-            treewalk_run(tw);
+            treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
             int64_t totalleft = 0;
             sumup_large_ints(1, &NPLeft, &totalleft);
@@ -353,7 +353,7 @@ void cooling_and_starformation(void)
         tw->postprocess = (TreeWalkProcessFunction) sfr_wind_feedback_postprocess;
         tw->reduce = NULL;
 
-        treewalk_run(tw);
+        treewalk_run(tw, ActiveParticle, NumActiveParticle);
         myfree(Wind);
     }
     walltime_measure("/Cooling/Wind");
@@ -384,7 +384,7 @@ void cooling_only(void)
     tw->haswork = sfr_cooling_haswork;
     tw->postprocess = (TreeWalkProcessFunction) cool_postprocess;
 
-    treewalk_run(tw);
+    treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
     walltime_measure("/Cooling/StarFormation");
 }

--- a/treewalk.c
+++ b/treewalk.c
@@ -238,7 +238,7 @@ static void real_ev(TreeWalk * tw) {
         if(P[i].Evaluated) {
             BREAKPOINT;
         }
-        if(!tw->isinteracting(i, tw)) {
+        if(!tw->haswork(i, tw)) {
             BREAKPOINT;
         }
         int rt;
@@ -276,7 +276,7 @@ int * treewalk_get_queue(TreeWalk * tw, int * len) {
         int i;
         #pragma omp parallel for
         for(i = 0; i < NumPart; i++) {
-            if(!tw->isinteracting(i, tw))
+            if(!tw->haswork(i, tw))
                 continue;
             const int lock = atomic_fetch_and_add(&k, 1);
             queue[lock] = i;
@@ -287,7 +287,7 @@ int * treewalk_get_queue(TreeWalk * tw, int * len) {
         for(i=0; i < NumActiveParticle; i++)
         {
             const int p_i = ActiveParticle[i];
-            if(!tw->isinteracting(p_i, tw))
+            if(!tw->haswork(p_i, tw))
                continue;
             const int lock = atomic_fetch_and_add(&k, 1);
             queue[lock] = p_i;

--- a/treewalk.h
+++ b/treewalk.h
@@ -70,7 +70,7 @@ enum TreeWalkType {
 };
 
 struct TreeWalk {
-    void * userdata;
+    void * priv;
 
     /* name of the evaluator (used in printing messages) */
     char * ev_label;

--- a/treewalk.h
+++ b/treewalk.h
@@ -117,8 +117,8 @@ struct TreeWalk {
     int BunchSize;
 
     struct ev_task * PrimaryTasks;
-    int * PQueue;
-    int PQueueSize;
+    int * WorkSet;
+    int WorkSetSize;
 
     /* per worker thread*/
     int *currentIndex;
@@ -126,7 +126,8 @@ struct TreeWalk {
 
 };
 
-void treewalk_run(TreeWalk * tw);
+void treewalk_run(TreeWalk * tw, int * active_set, int size);
+
 int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
             TreeWalkResultBase * O,
             LocalTreeWalk * lv);

--- a/treewalk.h
+++ b/treewalk.h
@@ -57,7 +57,7 @@ typedef int (*TreeWalkVisitFunction) (TreeWalkQueryBase * input, TreeWalkResultB
 
 typedef int (*TreeWalkNgbIterFunction) (TreeWalkQueryBase * input, TreeWalkResultBase * output, TreeWalkNgbIterBase * iter, LocalTreeWalk * lv);
 
-typedef int (*TreeWalkIsInteractingFunction) (const int i, TreeWalk * tw);
+typedef int (*TreeWalkHasWorkFunction) (const int i, TreeWalk * tw);
 typedef int (*TreeWalkProcessFunction) (const int i, TreeWalk * tw);
 
 typedef void (*TreeWalkFillQueryFunction)(const int j, TreeWalkQueryBase * query, TreeWalk * tw);
@@ -84,7 +84,7 @@ struct TreeWalk {
     binmask_t bgmask; /* if set, the bins to compute force from; used if TreeWalkType is SPLIT */
 
     TreeWalkVisitFunction visit;                /* Function to be called between a tree node and a particle */
-    TreeWalkIsInteractingFunction isinteracting; /* Is the particle part of this interaction? */
+    TreeWalkHasWorkFunction haswork; /* Is the particle part of this interaction? */
     TreeWalkFillQueryFunction fill;       /* Copy the useful attributes of a particle to a query */
     TreeWalkReduceResultFunction reduce;  /* Reduce a partial result to the local particle storage */
     TreeWalkNgbIterFunction ngbiter;     /* called for each pair of particles if visit is set to ngbiter */

--- a/treewalk.h
+++ b/treewalk.h
@@ -77,22 +77,24 @@ struct TreeWalk {
 
     enum TreeWalkType type;
 
-    binmask_t bgmask; /* if set, the bins to compute force from; used if TreeWalkType is SPLIT */
-
-    TreeWalkVisitFunction visit;
-    TreeWalkIsInteractingFunction isinteracting;
-    TreeWalkFillQueryFunction fill;
-    TreeWalkReduceResultFunction reduce;
-    TreeWalkNgbIterFunction ngbiter;
-    TreeWalkProcessFunction postprocess;
-
-    char * dataget;
-    char * dataresult;
-
-    int UseNodeList;
     size_t query_type_elsize;
     size_t result_type_elsize;
     size_t ngbiter_type_elsize;
+
+    binmask_t bgmask; /* if set, the bins to compute force from; used if TreeWalkType is SPLIT */
+
+    TreeWalkVisitFunction visit;                /* Function to be called between a tree node and a particle */
+    TreeWalkIsInteractingFunction isinteracting; /* Is the particle part of this interaction? */
+    TreeWalkFillQueryFunction fill;       /* Copy the useful attributes of a particle to a query */
+    TreeWalkReduceResultFunction reduce;  /* Reduce a partial result to the local particle storage */
+    TreeWalkNgbIterFunction ngbiter;     /* called for each pair of particles if visit is set to ngbiter */
+    TreeWalkProcessFunction postprocess; /* postprocess finalizes quantities for each particle, e.g. divide the normalization */
+    TreeWalkProcessFunction preprocess; /* Preprocess initializes quantities for each particle */
+
+    int UseNodeList;      /* Send tree branches or use the entire tree for ghost particles */
+
+    char * dataget;
+    char * dataresult;
 
     /* performance metrics */
     double timewait1;
@@ -125,7 +127,6 @@ struct TreeWalk {
 };
 
 void treewalk_run(TreeWalk * tw);
-int * treewalk_get_queue(TreeWalk * tw, int * len);
 int treewalk_visit_ngbiter(TreeWalkQueryBase * I,
             TreeWalkResultBase * O,
             LocalTreeWalk * lv);


### PR DESCRIPTION
This PR allows minimizes the treewalk interface, allows treewalk on any active set, updates a few names in treewalk, and eliminates almost all force related module global temp-variables.

- The code did ran to z=0 without dying on my test. I I tested density hydra and fof are giving identical results, but I do not know if they are correct for BH and SFR/COOL. f your test is stronger better run it too..

- After merging I think we shall merge ActiveParticle and NumActiveParticle to a single object, `ActiveParticleSet` which is an object of `ParticleSet`.

- The previous point highlights the lack of automated test cases. I had some idea, I'll write it down here too:
  - Upload a snapshot to amazon or somewhere with all particle types
  - finish `runtests()` to compute each force component of all particles or a subset, write the results
  - Write a python script / notebook that compares the result with known ones -- there are tools to run a notebook and diff it.
  - As the code stablizes we can add this to `.travis.yml`
