### PR TITLE
Domain cleanup

### DIFF
--- a/allvars.h
+++ b/allvars.h
@@ -520,7 +520,7 @@ extern struct particle_data
     pthread_spinlock_t SpinLock;
 #endif
 
-    int GravCost;     /*!< weight factor used for balancing the work-load */
+    float GravCost;     /*!< weight factor used for balancing the work-load */
 
     int Ti_begstep;     /*!< marks start of current timestep of particle on integer timeline */
     int Ti_drift;       /*!< current time of the particle position */

--- a/allvars.h
+++ b/allvars.h
@@ -520,7 +520,7 @@ extern struct particle_data
     pthread_spinlock_t SpinLock;
 #endif
 
-    float GravCost;     /*!< weight factor used for balancing the work-load */
+    int GravCost;     /*!< weight factor used for balancing the work-load */
 
     int Ti_begstep;     /*!< marks start of current timestep of particle on integer timeline */
     int Ti_drift;       /*!< current time of the particle position */

--- a/domain.c
+++ b/domain.c
@@ -913,6 +913,10 @@ int domain_determineTopTree(struct local_topnode_data * topNodes)
     //MPI_Barrier(MPI_COMM_WORLD);
     //MPI_Abort(MPI_COMM_WORLD, 0);
 #endif
+
+    /* FIXME: the previous function is already collective, so this step is not needed.
+     * We shall probably enforce that every 'long' function must be collective.
+     *  */
     MPI_Allreduce(&errflag, &errsum, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
     if(errsum)
@@ -1040,6 +1044,7 @@ void domain_add_cost(struct local_topnode_data *treeA, int noA, int64_t count, i
 }
 
 
+/* FIXME: this function needs some comments. I used to know what it does --. YF*/
 void domain_insertnode(struct local_topnode_data *treeA, struct local_topnode_data *treeB, int noA, int noB, struct local_topnode_data * topNodes)
 {
     int j, sub;

--- a/domain.c
+++ b/domain.c
@@ -239,6 +239,7 @@ void domain_free(void)
 static int64_t
 domain_particle_costfactor(int i)
 {
+    /* We round off GravCost to integer*/
     if(P[i].TimeBin)
         return (1 + P[i].GravCost) * (TIMEBASE / (1 << P[i].TimeBin));
     else

--- a/domain.c
+++ b/domain.c
@@ -357,7 +357,7 @@ domain_balance(void)
 static int
 domain_check_memory_bound(const int print_details, int64_t *TopLeafWork, int64_t *TopLeafCount)
 {
-    int ta, m, i;
+    int ta, i;
     int load, max_load;
     int64_t sumload;
     int64_t work, max_work, sumwork;
@@ -642,7 +642,6 @@ static void
 domain_create_topleaves(int no, int * next)
 {
     int i;
-    int rt = 0;
     if(TopNodes[no].Daughter == -1)
     {
         TopNodes[no].Leaf = *next;

--- a/domain.c
+++ b/domain.c
@@ -549,12 +549,26 @@ domain_assign_balanced(int64_t * cost)
     }
 }
 
-/*This function determines the TopLeaves entry for the given particle number.*/
+/*This function determines the TopLeaves entry for the given key.*/
 static inline int
 domain_get_topleaf(const peano_t key) {
     int no=0;
     while(TopNodes[no].Daughter >= 0)
         no = TopNodes[no].Daughter + (key - TopNodes[no].StartKey) / (TopNodes[no].Size / 8);
+    no = TopNodes[no].Leaf;
+    return no;
+}
+
+/* this function determines the TopLeaves entry for the given key, and returns the level of the
+ * node in terms of `shift`. */
+int
+domain_get_topleaf_with_shift(const peano_t key, int * shift) {
+    * shift = 3 * (BITS_PER_DIMENSION - 1);
+    int no=0;
+    while(TopNodes[no].Daughter >= 0) {
+        no = TopNodes[no].Daughter + (key - TopNodes[no].StartKey) / (TopNodes[no].Size / 8);
+        *shift -= 3;
+    }
     no = TopNodes[no].Leaf;
     return no;
 }
@@ -910,11 +924,11 @@ int domain_determineTopTree(struct local_topnode_data * topNodes)
 void domain_sumCost(int64_t *TopLeafWork, int64_t *TopLeafCount)
 {
     int i;
-    int64_t * local_TopLeafWork = (int64_t *) mymalloc("local_TopLeafWork", All.NumThreads * NTopLeaves * sizeof(local_TopLeafWork[0]));
-    int64_t * local_TopLeafCount = (int64_t *) mymalloc("local_TopLeafCount", All.NumThreads * NTopLeaves * sizeof(local_TopLeafCount[0]));
+    int64_t * local_TopLeafWork = (int64_t *) mymalloc("local_TopLeafWork", All.NumThreads * MaxTopNodes * sizeof(local_TopLeafWork[0]));
+    int64_t * local_TopLeafCount = (int64_t *) mymalloc("local_TopLeafCount", All.NumThreads * MaxTopNodes * sizeof(local_TopLeafCount[0]));
 
-    memset(local_TopLeafWork, 0, All.NumThreads * NTopLeaves * sizeof(local_TopLeafWork[0]));
-    memset(local_TopLeafCount, 0, All.NumThreads * NTopLeaves * sizeof(local_TopLeafCount[0]));
+    memset(local_TopLeafWork, 0, All.NumThreads * MaxTopNodes * sizeof(local_TopLeafWork[0]));
+    memset(local_TopLeafCount, 0, All.NumThreads * MaxTopNodes * sizeof(local_TopLeafCount[0]));
 
     NTopLeaves = 0;
     domain_walktoptree(0);

--- a/domain.c
+++ b/domain.c
@@ -84,7 +84,7 @@ static void domain_compute_costs(int64_t *TopLeafWork, int64_t *TopLeafCount);
 
 static void domain_insertnode(struct local_topnode_data *treeA, struct local_topnode_data *treeB, int noA, int noB, struct local_topnode_data * topNodes);
 static void domain_add_cost(struct local_topnode_data *treeA, int noA, int64_t count, int64_t cost);
-static int domain_check_for_local_refine(const int i, struct local_topnode_data * topNodes, int countlimit, double costlimit);
+static int domain_check_for_local_refine(const int i, struct local_topnode_data * topNodes, int64_t countlimit, int64_t costlimit);
 static void
 domain_create_topleaves(int no, int * next);
 
@@ -662,7 +662,7 @@ domain_create_topleaves(int no, int * next)
  * If 1 is returned on any processor we will return to domain_Decomposition,
  * allocate 30% more topNodes, and try again.
  * */
-int domain_check_for_local_refine(const int i, struct local_topnode_data * topNodes, int countlimit, double costlimit)
+int domain_check_for_local_refine(const int i, struct local_topnode_data * topNodes, int64_t countlimit, int64_t costlimit)
 {
     int j, p;
 

--- a/domain.h
+++ b/domain.h
@@ -4,23 +4,35 @@
 #include "peano.h"
 
 /*These variables are used externally in forcetree.c.
- * DomainTask is also used in treewalk and NTopleaves is used in gravpm.c*/
-extern int *DomainStartList, *DomainEndList;
-extern int *DomainTask;
+ * DomainTask is also used in treewalk and NTopLeaves is used in gravpm.c*/
 
 extern struct topnode_data
 {
     peano_t Size;		/*!< number of Peano-Hilbert mesh-cells represented by top-level node */
     peano_t StartKey;		/*!< first Peano-Hilbert key in top-level node */
     int Daughter;			/*!< index of first daughter cell (out of 8) of top-level node */
-    int Leaf;			/*!< if the node is a leaf, this gives its number when all leaves are traversed in Peano-Hilbert order */
+    int Leaf;			/*!< if the node is a leaf, this gives its index in topleaf_data */
 } *TopNodes;
+
+extern struct topleaf_data {
+    int Task;
+    union {
+        int topnode; /* used during domain_decompose for balancing the decomposition */
+        int treenode; /* used during life span of the tree for looking up in the tree Nodes */
+    };
+} * TopLeaves;
+
+extern struct task_data {
+    int StartLeaf;
+    int EndLeaf;
+} * Tasks;
+
 extern int MaxTopNodes;	        /*!< Maximum number of nodes in the top-level tree used for domain decomposition */
 
-
-extern int NTopnodes, NTopleaves;
+extern int NTopNodes, NTopLeaves;
 
 void domain_test_id_uniqueness();
 void domain_decompose_full(void);
 void domain_maintain(void);
+
 #endif

--- a/domain.h
+++ b/domain.h
@@ -35,4 +35,7 @@ void domain_test_id_uniqueness();
 void domain_decompose_full(void);
 void domain_maintain(void);
 
+int
+domain_get_topleaf_with_shift(const peano_t key, int * shift);
+
 #endif

--- a/examples/small/paramfile.gadget
+++ b/examples/small/paramfile.gadget
@@ -8,7 +8,7 @@ OutputList = 0.1,0.2,0.299,0.3,0.33333,0.4,0.5
 SnapshotFileBase = snapshot
 EnableAggregatedIO = 1
 Nmesh = 32
-
+DomainOverDecompositionFactor = 4
 # CPU time -limit
 	
 TimeLimitCPU = 43000 #= 8 hours

--- a/fof.c
+++ b/fof.c
@@ -1036,7 +1036,7 @@ fof_secondary_postprocess(int p, TreeWalk * tw)
 }
 static void fof_label_secondary(void)
 {
-    int i, n, iter;
+    int n, iter;
 
     TreeWalk tw[1] = {0};
     tw->ev_label = "FOF_FIND_NEAREST";

--- a/forcetree.c
+++ b/forcetree.c
@@ -721,7 +721,7 @@ force_update_node_recursive(int no, int sib, int father, int tail)
  */
 void force_exchange_pseudodata(void)
 {
-    int i, no, m, ta, recvTask;
+    int i, no, ta, recvTask;
     int *recvcounts, *recvoffset;
     struct topleaf_momentsdata
     {
@@ -928,7 +928,7 @@ void force_treeupdate_pseudos(int no)
 static void
 force_flag_localnodes(void)
 {
-    int no, i, m;
+    int no, i;
 
     /* mark all top-level nodes */
 
@@ -993,17 +993,13 @@ force_flag_localnodes(void)
 void force_update_hmax(int * activeset, int size)
 {
     int i, ta; 
-    int *domainList_all;
     int *counts, *offsets;
-    MyFloat *domainHmax_loc, *domainHmax_all;
     struct dirty_node_data {
         int treenode;
         MyFloat hmax;
     } * DirtyTopLevelNodes;
 
     int NumDirtyTopLevelNodes;
-
-    int totNumDirtyTopLevelNodes;
 
     walltime_measure("/Misc");
 

--- a/forcetree.h
+++ b/forcetree.h
@@ -43,7 +43,6 @@ extern int MaxNodes;		/*!< maximum allowed number of internal nodes */
 /*Used in domain.c*/
 extern int *Nextnode;		/*!< gives next node in tree walk  (nodes array) */
 extern int *Father;		/*!< gives parent node in tree (Prenodes array) */
-extern int *DomainNodeIndex;
 
 #define BITFLAG_TOPLEVEL                   0
 #define BITFLAG_DEPENDS_ON_LOCAL_MASS      1  /* Intersects with local mass */

--- a/forcetree.h
+++ b/forcetree.h
@@ -58,7 +58,7 @@ extern int *Father;		/*!< gives parent node in tree (Prenodes array) */
 
 int force_tree_allocated();
 
-void force_update_hmax(void);
+void force_update_hmax(int * activeset, int size);
 void force_tree_rebuild();
 
 void   force_tree_free(void);

--- a/gravpm.c
+++ b/gravpm.c
@@ -93,8 +93,8 @@ static PetaPMRegion * _prepare(void * userdata, int * Nregions) {
      *
      * */
     /* In worst case, each topleave becomes a region: thus
-     * NTopleaves is sufficient */
-    PetaPMRegion * regions = malloc(sizeof(PetaPMRegion) * NTopleaves);
+     * NTopLeaves is sufficient */
+    PetaPMRegion * regions = malloc(sizeof(PetaPMRegion) * NTopLeaves);
 
     int r = 0;
 

--- a/run.c
+++ b/run.c
@@ -385,7 +385,7 @@ void compute_accelerations(void)
         density();		/* computes density, and pressure */
 
         /***** update smoothing lengths in tree *****/
-        force_update_hmax();
+        force_update_hmax(ActiveParticle, NumActiveParticle);
 
         /***** hydro forces *****/
         message(0, "Start hydro-force computation...\n");

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -309,7 +309,6 @@ void cooling_and_starformation(void)
 #ifdef WINDS
     /* now lets make winds. this has to be after NumPart is updated */
     if(!HAS(All.WindModel, WINDS_SUBGRID) && All.WindModel != WINDS_NONE) {
-        int i;
         Wind = (struct winddata * ) mymalloc("WindExtraData", NumPart * sizeof(struct winddata));
         TreeWalk tw[1] = {0};
 

--- a/treewalk.c
+++ b/treewalk.c
@@ -268,12 +268,6 @@ static void real_ev(TreeWalk * tw) {
     tw->Nnodesinlist += lv->Nnodesinlist;
 }
 
-static int cmpint(const void * c1, const void * c2) {
-    const int* i1=c1;
-    const int* i2=c2;
-    return i1 - i2;
-}
-
 static void
 treewalk_build_queue(TreeWalk * tw, int * active_set, int size) {
     int * queue = tw->WorkSet;

--- a/treewalk.c
+++ b/treewalk.c
@@ -470,7 +470,8 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
     TreeWalk * tw = lv->tw;
     int task;
 
-    task = DomainTask[no - (All.MaxPart + MaxNodes)];
+    task = TopLeaves[no - (All.MaxPart + MaxNodes)].Task;
+
     if(exportflag[task] != target)
     {
         exportflag[task] = target;
@@ -503,7 +504,7 @@ int treewalk_export_particle(LocalTreeWalk * lv, int no) {
     if(tw->UseNodeList) 
     {
         DataNodeList[exportindex[task]].NodeList[exportnodecount[task]++] =
-            DomainNodeIndex[no - (All.MaxPart + MaxNodes)];
+            TopLeaves[no - (All.MaxPart + MaxNodes)].treenode;
 
         if(exportnodecount[task] < NODELISTLENGTH)
             DataNodeList[exportindex[task]].NodeList[exportnodecount[task]] = -1;


### PR DESCRIPTION
This PR removes the reference to a variety of 'Domain' objects in the source code. They are replaced with more precisely named variables, e.g. 

 - Domain decomposition Tree:  TopLeaves, TopNodes, Tasks
 - ForceTree : Nodes, TopLevelNodes 

algorithm for balancing is simplified. 
- for precise cumulation of cost they are all changed to int64. I hope we never overflow int64. (TimeBase is kind of big, but we still have about 40 bits)
- I hope the new code is more readable than the old one. It acts more like a state machine rather than recursion.

algorithm for update_hmax is clarified and simplified. 
- MPI_IN_PLACE looked nicer.
- Adding a struct for possibility of updating the moments with the same algorithm.
- extending this to any particle sets -- say if we want to recompute Hsml of the neighorbours.

the code currently runs, but a more through check would be nice..