### PR TITLE
Extratests

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -48,7 +48,7 @@ INCL   = allvars.h proto.h forcetree.h cooling.h domain.h treewalk.h \
 	 fof.h cosmology.h powerspectrum.h timestep.h sfr_eff.h drift.h timefac.h \
 	 petaio.h blackhole.h
 
-TESTED = interp powerspectrum
+TESTED = interp powerspectrum cosmology
 
 EXEC = $(TARGETS:%=$(DESTDIR)/%)
 OBJS = $(OBJECTS:%=$(DESTDIR)/%)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -48,7 +48,7 @@ INCL   = allvars.h proto.h forcetree.h cooling.h domain.h treewalk.h \
 	 fof.h cosmology.h powerspectrum.h timestep.h sfr_eff.h drift.h timefac.h \
 	 petaio.h blackhole.h
 
-TESTED = interp powerspectrum cosmology
+TESTED = interp powerspectrum cosmology timefac
 
 EXEC = $(TARGETS:%=$(DESTDIR)/%)
 OBJS = $(OBJECTS:%=$(DESTDIR)/%)

--- a/allvars.h
+++ b/allvars.h
@@ -312,8 +312,6 @@ extern struct global_data_all_processes
     /* Code options */
     int DomainOverDecompositionFactor; /* Number of sub-domains per processor. */
 
-    int TypeOfOpeningCriterion;	/*!< determines tree cell-opening criterion: 0 for Barnes-Hut, 1 for relative
-                                  criterion */
     int CoolingOn;		/*!< flags that cooling is enabled */
     double UVRedshiftThreshold;		/* Initial redshift of UV background. */
     int HydroOn;		/*!< flags that hydro force is enabled */
@@ -368,7 +366,6 @@ extern struct global_data_all_processes
 
     /* tree code opening criterion */
 
-    double ErrTolTheta;		/*!< BH tree opening angle */
     double ErrTolForceAcc;	/*!< parameter for relative opening criterion in tree walk */
 
     /*! The scale of the short-range/long-range force split in units of FFT-mesh cells */

--- a/allvars.h
+++ b/allvars.h
@@ -23,9 +23,6 @@
 #include <stdint.h>
 
 #include <gsl/gsl_rng.h>
-#include <gsl/gsl_math.h>
-#include <gsl/gsl_integration.h>
-#include <gsl/gsl_errno.h>
 
 #include <signal.h>
 #define BREAKPOINT raise(SIGTRAP)

--- a/begrun.c
+++ b/begrun.c
@@ -201,38 +201,9 @@ void close_outputfiles(void)
 static void
 set_units(void)
 {
-    /*With slightly relativistic massive neutrinos, for consistency we need to include radiation.
-     * A note on normalisation (as of 08/02/2012):
-     * CAMB appears to set Omega_Lambda + Omega_Matter+Omega_K = 1,
-     * calculating Omega_K in the code and specifying Omega_Lambda and Omega_Matter in the paramfile.
-     * This means that Omega_tot = 1+ Omega_r + Omega_g, effectively
-     * making h0 (very) slightly larger than specified, and the Universe is no longer flat!
-     */
-
-    All.CP.OmegaCDM = All.CP.Omega0 - All.CP.OmegaBaryon;
-    All.CP.OmegaK = 1.0 - All.CP.Omega0 - All.CP.OmegaLambda;
-
-    /* Omega_g = 4 \sigma_B T_{CMB}^4 8 \pi G / (3 c^3 H^2) */
-
-    All.CP.OmegaG = 4 * STEFAN_BOLTZMANN
-                  * pow(All.CP.CMBTemperature, 4)
-                  * (8 * M_PI * GRAVITY)
-                  / (3*C*C*C*HUBBLE*HUBBLE)
-                  / (All.CP.HubbleParam*All.CP.HubbleParam);
-
-    /* Neutrino + antineutrino background temperature as a ratio to T_CMB0
-     * Note there is a slight correction from 4/11
-     * due to the neutrinos being slightly coupled at e+- annihilation.
-     * See Mangano et al 2005 (hep-ph/0506164)
-     * The correction is (3.046/3)^(1/4), for N_eff = 3.046 */
-    double TNu0_TCMB0 = pow(4/11., 1/3.) * 1.00328;
-
-    /* For massless neutrinos,
-     * rho_nu/rho_g = 7/8 (T_nu/T_cmb)^4 *N_eff,
-     * but we absorbed N_eff into T_nu above. */
-    All.CP.OmegaNu0 = All.CP.OmegaG * 7. / 8 * pow(TNu0_TCMB0, 4) * 3;
-
     double meanweight;
+
+    init_cosmology();
 
     All.UnitTime_in_s = All.UnitLength_in_cm / All.UnitVelocity_in_cm_per_s;
     All.UnitTime_in_Megayears = All.UnitTime_in_s / SEC_PER_MEGAYEAR;

--- a/blackhole.c
+++ b/blackhole.c
@@ -434,7 +434,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             /* FIXME: volume correction doesn't work on BH yet. */
             O->Rho += (mass_j * wk);
 
-            O->SmoothedPressure += (mass_j * wk * PressurePred(other, All.Ti_Current));
+            O->SmoothedPressure += (mass_j * wk * PressurePred(other));
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
             O->GasVel[0] += (mass_j * wk * VelPred[0]);
             O->GasVel[1] += (mass_j * wk * VelPred[1]);

--- a/cosmology.c
+++ b/cosmology.c
@@ -2,6 +2,7 @@
 #include "allvars.h"
 #include "cosmology.h"
 #include "endrun.h"
+#include <gsl/gsl_integration.h>
 #include <gsl/gsl_odeiv2.h>
 
 void init_cosmology()

--- a/cosmology.c
+++ b/cosmology.c
@@ -1,7 +1,6 @@
 #include <math.h>
 #include "allvars.h"
 #include "cosmology.h"
-#include "utils-string.h"
 
 /*Hubble function at scale factor a, in dimensions of All.Hubble*/
 double hubble_function(double a)
@@ -87,46 +86,6 @@ static double sigma2_int(double k, void * p)
     x = 4 * M_PI * k * k * w * w * function_of_k_eval(fk, k);
 
     return x;
-}
-
-FunctionOfK * function_of_k_new_from_string(const char * string, int logscale)
-{
-    FunctionOfK * fk = NULL;
-    char ** list = fastpm_strsplit(string, "\n");
-    char ** line;
-    int i;
-    int pass = 0;
-    /* two pass parsing, first pass for counting */
-    /* second pass for assignment */
-    while(pass < 2) {
-        i = 0;
-        for (line = list; *line; line++) {
-            double k, p;
-            if(2 == sscanf(*line, "%lg %lg", &k, &p)) {
-                if(logscale) {
-                    k = pow(10, k);
-                    p = pow(10, p);
-                }
-                if(pass == 1) {
-                    fk->table[i].k = k;
-                    fk->table[i].P = p;
-                }
-                i ++;
-            }
-        }
-
-        if(pass == 0) {
-            fk = malloc(sizeof(*fk) + sizeof(fk->table[0]) * i);
-            fk->bytesize = sizeof(*fk) + sizeof(fk->table[0]) * i;
-            fk->size = i;
-            fk->normfactor = 1;
-        }
-        pass ++;
-    }
-
-    free(list);
-
-    return 0;
 }
 
 double function_of_k_eval(FunctionOfK * fk, double k)

--- a/cosmology.c
+++ b/cosmology.c
@@ -2,6 +2,39 @@
 #include "allvars.h"
 #include "cosmology.h"
 
+void init_cosmology()
+{
+    /*With slightly relativistic massive neutrinos, for consistency we need to include radiation.
+     * A note on normalisation (as of 08/02/2012):
+     * CAMB appears to set Omega_Lambda + Omega_Matter+Omega_K = 1,
+     * calculating Omega_K in the code and specifying Omega_Lambda and Omega_Matter in the paramfile.
+     * This means that Omega_tot = 1+ Omega_r + Omega_g, effectively
+     * making h0 (very) slightly larger than specified, and the Universe is no longer flat!
+     */
+    All.CP.OmegaCDM = All.CP.Omega0 - All.CP.OmegaBaryon;
+    All.CP.OmegaK = 1.0 - All.CP.Omega0 - All.CP.OmegaLambda;
+
+    /* Omega_g = 4 \sigma_B T_{CMB}^4 8 \pi G / (3 c^3 H^2) */
+
+    All.CP.OmegaG = 4 * STEFAN_BOLTZMANN
+                  * pow(All.CP.CMBTemperature, 4)
+                  * (8 * M_PI * GRAVITY)
+                  / (3*C*C*C*HUBBLE*HUBBLE)
+                  / (All.CP.HubbleParam*All.CP.HubbleParam);
+
+    /* Neutrino + antineutrino background temperature as a ratio to T_CMB0
+     * Note there is a slight correction from 4/11
+     * due to the neutrinos being slightly coupled at e+- annihilation.
+     * See Mangano et al 2005 (hep-ph/0506164)
+     * The correction is (3.046/3)^(1/4), for N_eff = 3.046 */
+    double TNu0_TCMB0 = pow(4/11., 1/3.) * 1.00328;
+
+    /* For massless neutrinos,
+     * rho_nu/rho_g = 7/8 (T_nu/T_cmb)^4 *N_eff,
+     * but we absorbed N_eff into T_nu above. */
+    All.CP.OmegaNu0 = All.CP.OmegaG * 7. / 8 * pow(TNu0_TCMB0, 4) * 3;
+}
+
 /*Hubble function at scale factor a, in dimensions of All.Hubble*/
 double hubble_function(double a)
 {

--- a/cosmology.h
+++ b/cosmology.h
@@ -32,6 +32,9 @@ double function_of_k_tophat_sigma(FunctionOfK * fk, double R);
 double hubble_function(double a);
 /* Linear theory growth factor normalized to D(a=1.0) = 1.0. */
 double GrowthFactor(double a);
+/*Note this is only used in GenIC*/
 double F_Omega(double a);
 
+/*Initialise the derived parts of the cosmology*/
+void init_cosmology(void);
 #endif

--- a/cosmology.h
+++ b/cosmology.h
@@ -23,8 +23,6 @@ typedef struct {
     } table[];
 } FunctionOfK;
 
-FunctionOfK * function_of_k_new_from_string(const char * string, int logscale);
-
 void function_of_k_normalize_sigma(FunctionOfK * fk, double R, double sigma);
 
 double function_of_k_eval(FunctionOfK * fk, double k);

--- a/density.c
+++ b/density.c
@@ -320,7 +320,7 @@ density_ngbiter(
         O->DhsmlDensity += mass_j * density_kernel_dW(&iter->kernel, u, wk, dwk);
 
 #ifdef DENSITY_INDEPENDENT_SPH
-        double EntPred = EntropyPred(other, All.Ti_Current);
+        double EntPred = EntropyPred(other);
         O->EgyRho += mass_j * EntPred * wk;
         O->DhsmlEgyDensity += mass_j * EntPred * density_kernel_dW(&iter->kernel, u, wk, dwk);
 #endif
@@ -387,7 +387,7 @@ density_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DhsmlDensityFactor = 1;
 
 #ifdef DENSITY_INDEPENDENT_SPH
-            const double EntPred = EntropyPred(i, All.Ti_Current);
+            const double EntPred = EntropyPred(i);
             if((EntPred > 0) && (SPHP(i).EgyWtDensity>0))
             {
                 SPHP(i).DhsmlEgyDensityFactor *= P[i].Hsml/ (NUMDIMS * SPHP(i).EgyWtDensity);

--- a/examples/lya/paramfile.gadget
+++ b/examples/lya/paramfile.gadget
@@ -54,8 +54,6 @@ MinSizeTimestep = 0.05
 
 # Tree algorithm, force accuracy, domain update frequency
 
-ErrTolTheta = 0.5            
-TypeOfOpeningCriterion = 1
 ErrTolForceAcc = 0.005
 
 #  Further parameters of SPH

--- a/global.c
+++ b/global.c
@@ -91,7 +91,7 @@ struct state_of_system compute_global_quantities_of_system(void)
 
         if(P[i].Type == 0)
         {
-            entr = EntropyPred(i, All.Ti_Current);
+            entr = EntropyPred(i);
             egyspec = entr / (GAMMA_MINUS1) * pow(SPHP(i).EOMDensity / a3, GAMMA_MINUS1);
             sys.EnergyIntComp[0] += P[i].Mass * egyspec;
             sys.TemperatureComp[0] += P[i].Mass * ConvertInternalEnergy2Temperature(egyspec, SPHP(i).Ne);

--- a/global.c
+++ b/global.c
@@ -6,6 +6,7 @@
 
 #include "allvars.h"
 #include "timefac.h"
+#include "timestep.h"
 #include "cooling.h"
 #include "endrun.h"
 
@@ -90,8 +91,7 @@ struct state_of_system compute_global_quantities_of_system(void)
 
         if(P[i].Type == 0)
         {
-            double Fentr = (All.Ti_Current - (P[i].Ti_begstep + dti / 2)) * All.Timebase_interval;
-            entr = SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr;
+            entr = EntropyPred(i, All.Ti_Current);
             egyspec = entr / (GAMMA_MINUS1) * pow(SPHP(i).EOMDensity / a3, GAMMA_MINUS1);
             sys.EnergyIntComp[0] += P[i].Mass * egyspec;
             sys.TemperatureComp[0] += P[i].Mass * ConvertInternalEnergy2Temperature(egyspec, SPHP(i).Ne);

--- a/gravshort-tree-old.c
+++ b/gravshort-tree-old.c
@@ -98,11 +98,6 @@ void grav_short_tree_old(void)
 
     treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
-    if(All.TypeOfOpeningCriterion == 1) {
-        /* This will switch to the relative opening criterion for the following force computations */
-        All.ErrTolTheta = 0;
-    }
-
     /* now add things for comoving integration */
 
     message(0, "tree is done.\n");
@@ -382,35 +377,24 @@ force_treeevaluate_shortrange(TreeWalkQueryGravShort * input,
                 }
 
 
-                if(All.ErrTolTheta)	/* check Barnes-Hut opening criterion */
+                /* check relative opening criterion */
+                if(mass * nop->len * nop->len > r2 * r2 * aold)
                 {
-                    if(nop->len * nop->len > r2 * All.ErrTolTheta * All.ErrTolTheta)
-                    {
-                        /* open cell */
-                        no = nop->u.d.nextnode;
-                        continue;
-                    }
+                    /* open cell */
+                    no = nop->u.d.nextnode;
+                    continue;
                 }
-                else		/* check relative opening criterion */
+
+                /* check in addition whether we lie inside the cell */
+
+                if(fabs(nop->center[0] - pos_x) < 0.60 * nop->len)
                 {
-                    if(mass * nop->len * nop->len > r2 * r2 * aold)
+                    if(fabs(nop->center[1] - pos_y) < 0.60 * nop->len)
                     {
-                        /* open cell */
-                        no = nop->u.d.nextnode;
-                        continue;
-                    }
-
-                    /* check in addition whether we lie inside the cell */
-
-                    if(fabs(nop->center[0] - pos_x) < 0.60 * nop->len)
-                    {
-                        if(fabs(nop->center[1] - pos_y) < 0.60 * nop->len)
+                        if(fabs(nop->center[2] - pos_z) < 0.60 * nop->len)
                         {
-                            if(fabs(nop->center[2] - pos_z) < 0.60 * nop->len)
-                            {
-                                no = nop->u.d.nextnode;
-                                continue;
-                            }
+                            no = nop->u.d.nextnode;
+                            continue;
                         }
                     }
                 }

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -71,11 +71,6 @@ void grav_short_tree(void)
 
     treewalk_run(tw, ActiveParticle, NumActiveParticle);
 
-    if(All.TypeOfOpeningCriterion == 1) {
-        /* This will switch to the relative opening criterion for the following force computations */
-        All.ErrTolTheta = 0;
-    }
-
     /* now add things for comoving integration */
 
     message(0, "tree is done.\n");
@@ -270,36 +265,22 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                     }
                 }
 
-
-                if(All.ErrTolTheta)	/* check Barnes-Hut opening criterion */
+                /* check relative opening criterion */
+                if(mass * nop->len * nop->len > r2 * r2 * aold)
                 {
-                    if(nop->len * nop->len > r2 * All.ErrTolTheta * All.ErrTolTheta)
-                    {
-                        /* open cell */
-                        no = nop->u.d.nextnode;
-                        continue;
-                    }
+                    /* open cell */
+                    no = nop->u.d.nextnode;
+                    continue;
                 }
-                else		/* check relative opening criterion */
+                /* check in addition whether we lie inside the cell */
+                if(fabs(nop->center[0] - pos_x) < 0.60 * nop->len)
                 {
-                    if(mass * nop->len * nop->len > r2 * r2 * aold)
+                    if(fabs(nop->center[1] - pos_y) < 0.60 * nop->len)
                     {
-                        /* open cell */
-                        no = nop->u.d.nextnode;
-                        continue;
-                    }
-
-                    /* check in addition whether we lie inside the cell */
-
-                    if(fabs(nop->center[0] - pos_x) < 0.60 * nop->len)
-                    {
-                        if(fabs(nop->center[1] - pos_y) < 0.60 * nop->len)
+                        if(fabs(nop->center[2] - pos_z) < 0.60 * nop->len)
                         {
-                            if(fabs(nop->center[2] - pos_z) < 0.60 * nop->len)
-                            {
-                                no = nop->u.d.nextnode;
-                                continue;
-                            }
+                            no = nop->u.d.nextnode;
+                            continue;
                         }
                     }
                 }

--- a/hydra.c
+++ b/hydra.c
@@ -136,13 +136,13 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
     input->Density = SPHP(place).Density;
 #ifdef DENSITY_INDEPENDENT_SPH
     input->EgyRho = SPHP(place).EgyWtDensity;
-    input->EntVarPred = EntropyPred(place, All.Ti_Current);
+    input->EntVarPred = EntropyPred(place);
     input->DhsmlDensityFactor = SPHP(place).DhsmlEgyDensityFactor;
 #else
     input->DhsmlDensityFactor = SPHP(place).DhsmlDensityFactor;
 #endif
 
-    input->Pressure = PressurePred(place, All.Ti_Current);
+    input->Pressure = PressurePred(place);
     input->Timestep = (P[place].TimeBin ? (1 << P[place].TimeBin) : 0);
     /* calculation of F1 */
     soundspeed_i = sqrt(GAMMA * input->Pressure / SPHP(place).EOMDensity);
@@ -230,7 +230,7 @@ hydro_ngbiter(
 
     if(r2 > 0 && (r2 < iter->kernel_i.HH || r2 < kernel_j.HH))
     {
-        double Pressure_j = PressurePred(other, All.Ti_Current);
+        double Pressure_j = PressurePred(other);
         double p_over_rho2_j = Pressure_j / (SPHP(other).EOMDensity * SPHP(other).EOMDensity);
         double soundspeed_j;
 
@@ -303,7 +303,7 @@ hydro_ngbiter(
 #ifdef DENSITY_INDEPENDENT_SPH
         double hfc = hfc_visc;
         /* leading-order term */
-        double EntPred = EntropyPred(other, All.Ti_Current);
+        double EntPred = EntropyPred(other);
         hfc += P[other].Mass *
             (dwk_i*iter->p_over_rho2_i*EntPred/I->EntVarPred +
              dwk_j*p_over_rho2_j*I->EntVarPred/EntPred) / r;
@@ -380,7 +380,7 @@ hydro_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DtEntropy = 0;
 
 #ifdef NOWINDTIMESTEPPING
-                SPHP(i).MaxSignalVel = 2 * sqrt(GAMMA * PressurePred(i,All.Ti_Current) / SPHP(i).Density);
+                SPHP(i).MaxSignalVel = 2 * sqrt(GAMMA * PressurePred(i) / SPHP(i).Density);
 #else
                 double windspeed = All.WindSpeed * All.cf.a;
                 const double fac_mu = pow(All.cf.a, 3 * (GAMMA - 1) / 2) / All.cf.a;

--- a/param.c
+++ b/param.c
@@ -143,10 +143,8 @@ create_gadget_parameter_set()
     param_declare_double(ps, "TimeLimitCPU", REQUIRED, 0, "");
 
     param_declare_int   (ps, "DomainOverDecompositionFactor", OPTIONAL, 1, "Number of sub domains on a MPI rank");
-    param_declare_double(ps, "ErrTolTheta", OPTIONAL, 0.5, "");
-    param_declare_int(ps,    "TypeOfOpeningCriterion", OPTIONAL, 1, "");
     param_declare_double(ps, "ErrTolIntAccuracy", OPTIONAL, 0.02, "");
-    param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "");
+    param_declare_double(ps, "ErrTolForceAcc", OPTIONAL, 0.005, "Force accuracy required from tree. Controls tree opening criteria. Lower values are more accurate.");
     param_declare_double(ps, "Asmth", OPTIONAL, 1.25, "The scale of the short-range/long-range force split in units of FFT-mesh cells. Gadget-2 paper says larger values may be more accurate.");
     param_declare_int(ps,    "Nmesh", REQUIRED, 0, "");
 
@@ -356,7 +354,6 @@ void read_parameter_file(char *fname)
         All.CpuTimeBetRestartFile = param_get_double(ps, "CpuTimeBetRestartFile");
 
         All.TimeMax = param_get_double(ps, "TimeMax");
-        All.ErrTolTheta = param_get_double(ps, "ErrTolTheta");
         All.ErrTolIntAccuracy = param_get_double(ps, "ErrTolIntAccuracy");
         All.ErrTolForceAcc = param_get_double(ps, "ErrTolForceAcc");
         All.Asmth = param_get_double(ps, "Asmth");
@@ -391,7 +388,6 @@ void read_parameter_file(char *fname)
         All.TreeGravOn = param_get_int(ps, "TreeGravOn");
         All.FastParticleType = param_get_int(ps, "FastParticleType");
         All.StarformationOn = param_get_int(ps, "StarformationOn");
-        All.TypeOfOpeningCriterion = param_get_int(ps, "TypeOfOpeningCriterion");
         All.TimeLimitCPU = param_get_double(ps, "TimeLimitCPU");
         All.SofteningHalo = param_get_double(ps, "SofteningHalo");
         All.SofteningDisk = param_get_double(ps, "SofteningDisk");

--- a/proto.h
+++ b/proto.h
@@ -7,8 +7,6 @@ void begrun(int RestartFlag, int RestartSnapNum);
 void density(void);
 void energy_statistics(void);
 
-int find_next_outputtime(int time);
-
 void grav_short_tree(void);
 void hydro_force(void);
 void init(int RestartSnapNum);

--- a/run.c
+++ b/run.c
@@ -370,7 +370,7 @@ void compute_accelerations(void)
 
     grav_short_tree();		/* computes gravity accel. */
 
-    if(All.TypeOfOpeningCriterion == 1 && All.Ti_Current == 0)
+    if(All.Ti_Current == 0)
         grav_short_tree();		/* For the first timestep, we redo it
                              * to allow usage of relative opening
                              * criterion for consistent accuracy.

--- a/test/cosmology_test.c
+++ b/test/cosmology_test.c
@@ -1,0 +1,96 @@
+/*Tests for the cosmology module, ported from N-GenIC.*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <math.h>
+#include <stdio.h>
+#include "../cosmology.h"
+//So All.CP is defined
+#include "../allvars.h"
+#include <gsl/gsl_sf_hyperg.h>
+
+void endrun(int ierr, const char * fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    printf(fmt, va);
+    va_end(va);
+    exit(1);
+}
+struct global_data_all_processes All;
+int64_t NTotal[6] = {0};
+
+void setup_cosmology(double Omega0, double OmegaBaryon, double H0)
+{
+    All.CP.CMBTemperature = 2.7255;
+    All.CP.Omega0 = Omega0;
+    All.CP.OmegaLambda = 1- All.CP.Omega0;
+    All.CP.OmegaBaryon = OmegaBaryon;
+    All.CP.HubbleParam = H0;
+
+    /*Default value for L=kpc v=km/s*/
+    All.UnitTime_in_s = 3.08568e+16;
+    /*Should be 0.1*/
+    All.Hubble = HUBBLE * All.UnitTime_in_s;
+    /*Do the main cosmology initialisation*/
+    init_cosmology();
+}
+
+inline double radgrow(double aa, double omegar) {
+    return omegar + 1.5 * 1. * aa; 
+}
+
+//Omega_L + Omega_M = 1 => D+ ~ Gauss hypergeometric function
+inline double growth(double aa, double omegam) {
+    double omegal = 1-omegam;
+    return aa * gsl_sf_hyperg_2F1(1./3, 1, 11./6, -omegal/omegam*pow(aa,3));
+}
+
+static void test_cosmology(void ** state)
+{
+    //Check that we get the right scalings for total matter domination.
+    //Cosmology(double HubbleParam, double Omega, double OmegaLambda, double MNu, int Hierarchy, bool NoRadiation)
+    setup_cosmology(1., 0.0455, 0.7);
+    /*Check some of the setup worked*/
+    assert_true(All.CP.OmegaK < 1e-5);
+    assert_true(fabs(All.CP.OmegaG/5.045e-5 - 1) < 2e-3);
+    /*Check the hubble function is sane*/
+    All.CP.RadiationOn = 0;
+    assert_true(fabs(hubble_function(1) - All.Hubble) < 1e-5);
+    All.CP.RadiationOn = 1;
+    assert_true(fabs(hubble_function(1) - All.Hubble* sqrt(1+All.CP.OmegaNu0+All.CP.OmegaG)) < 1e-7);
+
+    assert_true(fabs(All.Hubble - 0.1) < 1e-6);
+    assert_true((hubble_function(1) - All.Hubble) < 1e-5);
+    assert_true(fabs(hubble_function(0.1) - hubble_function(1)/pow(0.1,3/2.)) < 1e-2);
+    assert_true(fabs(GrowthFactor(0.5)/0.5 -1) < 2e-4);
+    //Check that massless neutrinos work
+    assert_true(fabs(All.CP.OmegaNu0 - All.CP.OmegaG*7./8.*pow(pow(4/11.,1/3.)*1.00328,4)*3) < 2e-5);
+    //Check that the velocity correction d ln D1/d lna is constant
+    assert_true(fabs(1.0 - F_Omega(1.5)) < 1e-1);
+    assert_true(fabs(1.0 - F_Omega(2)) < 1e-2);
+    //Check radiation against exact solution from gr-qc/0504089
+    double omegar = All.CP.OmegaG + All.CP.OmegaNu0;
+    assert_true(fabs(1/GrowthFactor(0.05) - radgrow(1., omegar)/radgrow(0.05, omegar))< 1e-3);
+    assert_true(fabs(GrowthFactor(0.01)/GrowthFactor(0.001) - radgrow(0.01, omegar)/radgrow(0.001, omegar))< 1e-3);
+
+    //Check against exact solutions from gr-qc/0504089: No radiation!
+    //Note that the GSL hyperg needs the last argument to be < 1
+    double omegam = 0.5;
+    setup_cosmology(omegam, 0.0455, 0.7);
+    All.CP.RadiationOn = 0;
+    //Check growth factor during matter domination
+    assert_true(fabs(1/GrowthFactor(0.5) - growth(1., omegam)/growth(0.5, omegam)) < 1e-3);
+    assert_true(fabs(GrowthFactor(0.3)/GrowthFactor(0.15) - growth(0.3, omegam)/growth(0.15, omegam)) < 1e-3);
+    assert_true(fabs(1/GrowthFactor(0.01) - growth(1, omegam)/growth(0.01, omegam)) < 1e-3);
+    assert_true(fabs(0.01*log(GrowthFactor(0.01+1e-5)/GrowthFactor(0.01-1e-5))/2e-5 -  F_Omega(0.01)) < 1e-3);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_cosmology),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/timefac_test.c
+++ b/test/timefac_test.c
@@ -66,6 +66,7 @@ double exact_drift_factor(double a1, double a2, int exp)
     F.function = &fac_integ;
     F.params = &exp;
     gsl_integration_qag(&F, a1,a2, 0, 1.0e-8, 10000, GSL_INTEG_GAUSS61, workspace, &result, &abserr);
+    gsl_integration_workspace_free(workspace);
     return result;
 }
 

--- a/test/timefac_test.c
+++ b/test/timefac_test.c
@@ -1,0 +1,109 @@
+/*Tests for the drift factor module.*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <gsl/gsl_integration.h>
+#include "../timefac.h"
+
+#define AMIN 0.005
+#define AMAX 1.0
+#define TIMEBINS 29
+
+/*Mock functions for linker*/
+void endrun(int ierr, const char * fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    printf(fmt, va);
+    va_end(va);
+    exit(1);
+}
+
+static double OmegaM;
+/*Hubble function at scale factor a, in dimensions of All.Hubble*/
+double hubble_function(double a)
+{
+    double hubble_a;
+    /* lambda and matter */
+    hubble_a = 1 - OmegaM;
+    hubble_a += OmegaM / (a * a * a);
+    /*Radiation*/
+    hubble_a += 5.045e-5*(1+7./8.*pow(pow(4/11.,1/3.)*1.00328,4)*3) / (a * a * a * a);
+    /* Hard-code default Gadget unit system. */
+    hubble_a = 0.1 * sqrt(hubble_a);
+    return (hubble_a);
+}
+
+double fac_integ(double a, void *param)
+{
+  double h;
+  int ex = * (int *) param;
+
+  h = hubble_function(a);
+
+  return 1 / (h * pow(a,ex));
+}
+
+/*Get integer from real time*/
+inline int get_ti(double aa)
+{
+    double logDTime = (log(AMAX) - log(AMIN)) / (1 << TIMEBINS);
+    return (log(aa) - log(AMIN))/logDTime;
+}
+
+double exact_drift_factor(double a1, double a2, int exp)
+{
+    double result, abserr;
+    gsl_function F;
+    gsl_integration_workspace *workspace;
+    workspace = gsl_integration_workspace_alloc(10000);
+    F.function = &fac_integ;
+    F.params = &exp;
+    gsl_integration_qag(&F, a1,a2, 0, 1.0e-8, 10000, GSL_INTEG_GAUSS61, workspace, &result, &abserr);
+    return result;
+}
+
+void test_drift_factor(void ** state)
+{
+    /*Initialise the table: default values from z=200 to z=0*/
+    OmegaM = 1.;
+    init_drift_table(AMIN, AMAX, 1<<TIMEBINS);
+    /* Check default scaling: for total matter domination
+     * we should have a drift factor like 1/sqrt(a)*/
+    assert_true(fabs(get_drift_factor(get_ti(0.8), get_ti(0.85)) + 2/0.1*(1/sqrt(0.85) - 1/sqrt(0.8))) < 5e-5);
+    /*Test the kick table*/
+    assert_true(fabs(get_gravkick_factor(get_ti(0.8), get_ti(0.85)) - 2/0.1*(sqrt(0.85) - sqrt(0.8))) < 5e-5);
+
+    //Chosen so we get the same bin
+    assert_true(fabs(get_drift_factor(get_ti(0.8), get_ti(0.8003)) + 2/0.1*(1/sqrt(0.8003) - 1/sqrt(0.8))) < 5e-6);
+    //Now choose a more realistic cosmology
+    OmegaM = 0.25;
+    init_drift_table(AMIN, AMAX, 1<<TIMEBINS);
+    /*Check late and early times*/
+    assert_true(fabs(get_drift_factor(get_ti(0.95), get_ti(0.98)) - exact_drift_factor(0.95, 0.98,3)) < 5e-5);
+    assert_true(fabs(get_drift_factor(get_ti(0.05), get_ti(0.06)) - exact_drift_factor(0.05, 0.06,3)) < 5e-5);
+    /*Check boundary conditions*/
+    double logDtime = (log(AMAX)-log(AMIN))/(1<<TIMEBINS);
+    assert_true(fabs(get_drift_factor(((1<<TIMEBINS)-1), 1<<TIMEBINS) - exact_drift_factor(AMAX-logDtime, AMAX,3)) < 5e-5);
+    assert_true(fabs(get_drift_factor(0, 1) - exact_drift_factor(1.0 - exp(log(AMAX)-log(AMIN))/(1<<TIMEBINS), 1.0,3)) < 5e-5);
+    /*Gravkick*/
+    assert_true(fabs(get_gravkick_factor(get_ti(0.8), get_ti(0.85)) - exact_drift_factor(0.8, 0.85, 2)) < 5e-5);
+    assert_true(fabs(get_gravkick_factor(get_ti(0.05), get_ti(0.06)) - exact_drift_factor(0.05, 0.06, 2)) < 5e-5);
+
+    /*Test the hydrokick table: always the same as drift*/
+    assert_true(fabs(get_hydrokick_factor(get_ti(0.8), get_ti(0.85)) - get_drift_factor(get_ti(0.8), get_ti(0.85))) < 5e-5);
+
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_drift_factor),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/timestep.c
+++ b/timestep.c
@@ -368,21 +368,15 @@ void sph_VelPred(int i, double * VelPred)
 
 /* This gives the predicted entropy at the particle Kick timestep
  * for the density independent SPH code.*/
-double EntropyPred(int i, int ti)
+double EntropyPred(int i)
 {
-    if (ti != P[i].Ti_drift) {
-        endrun(1, "ti %d != Drift step %d != t: %d\n",ti, P[i].Ti_drift);
-    }
-    const double Fentr = (ti - P[i].Ti_kick) * All.Timebase_interval;
+    const double Fentr = (P[i].Ti_drift - P[i].Ti_kick) * All.Timebase_interval;
     return pow(SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr, 1/GAMMA);
 }
 
-double PressurePred(int i, int ti)
+double PressurePred(int i)
 {
-    if (ti != P[i].Ti_drift) {
-        endrun(1, "ti %d != Drift step %d != t: %d\n",ti, P[i].Ti_drift);
-    }
-    const double Fentr = (ti - P[i].Ti_kick) * All.Timebase_interval;
+    const double Fentr = (P[i].Ti_drift - P[i].Ti_kick) * All.Timebase_interval;
     return (SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr) * pow(SPHP(i).EOMDensity, GAMMA);
 }
 
@@ -501,8 +495,8 @@ get_timestep_ti(const int p, const int dti_max)
                     SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb);
 #ifdef DENSITY_INDEPENDENT_SPH
         if(P[p].Type == 0)
-            message(1, "egyrho=%g entvarpred=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g, Pressure=%g\n", SPHP(p).EgyWtDensity, EntropyPred(p,P[p].Ti_drift),
-                    SPHP(p).DhsmlEgyDensityFactor, SPHP(p).Entropy, SPHP(p).DtEntropy, PressurePred(p,P[p].Ti_drift));
+            message(1, "egyrho=%g entvarpred=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g, Pressure=%g\n", SPHP(p).EgyWtDensity, EntropyPred(p),
+                    SPHP(p).DhsmlEgyDensityFactor, SPHP(p).Entropy, SPHP(p).DtEntropy, PressurePred(p));
 #endif
 #ifdef SFR
         if(P[p].Type == 0) {

--- a/timestep.h
+++ b/timestep.h
@@ -21,8 +21,8 @@ int is_timebin_active(int i);
 void set_timebin_active(binmask_t mask);
 
 void sph_VelPred(int i, double * VelPred);
-double EntropyPred(int i, int ti);
-double PressurePred(int i, int ti);
+double EntropyPred(int i);
+double PressurePred(int i);
 
 static inline double get_dloga_for_bin(int timebin)
 {

--- a/treewalk.c
+++ b/treewalk.c
@@ -1,4 +1,5 @@
 #include <mpi.h>
+#include <math.h>
 #include <string.h>
 #include <stdlib.h>
 #include "allvars.h"


### PR DESCRIPTION
This pull request adds some unit tests for the cosmology module and the timefac module. It then makes sure they pass.

This means:
- Porting the better growth function solutions from N-GenIC (only affects GenIC with radiation on)
- Slightly increasing the size of the lookup table in timefac.c

There are also some (largely unrelated) cleanups to the prediction functions, and I remove TypeOfOpeningCriterion because we never used it.