### PR TITLE
Cleaner time step bookkeeping.

### DIFF
--- a/allvars.h
+++ b/allvars.h
@@ -506,11 +506,8 @@ extern struct particle_data
 
     float GravCost;     /*!< weight factor used for balancing the work-load */
 
-    inttime_t Ti_begstep;     /*!< marks start of current timestep of particle on integer timeline */
     inttime_t Ti_drift;       /*!< current time of the particle position */
-#ifdef DEBUG
     inttime_t Ti_kick;        /*!< current time of the particle momentum */
-#endif
 
     double Pos[3];   /*!< particle position at its current time */
     float Mass;     /*!< particle mass */

--- a/timestep.c
+++ b/timestep.c
@@ -266,9 +266,9 @@ apply_half_kick(void)
         const int i = ActiveParticle[pa];
         int bin = P[i].TimeBin;
         inttime_t dti = dti_from_timebin(bin);
-        /* Start of step*/
+        /* current Kick time */
         inttime_t tistart = P[i].Ti_kick;
-        /* Midpoint of step*/
+        /* half of a step */
         inttime_t tiend = get_kick_ti(P[i].Ti_kick, dti);
         /*This only changes particle i, so is thread-safe.*/
         do_the_short_range_kick(i, tistart, tiend);

--- a/timestep.c
+++ b/timestep.c
@@ -28,12 +28,6 @@ typedef struct {
 
 static TimeSpan PM;
 
-/*Get the kick time for a timestep, given a start point and a step size.*/
-inline int get_kick_ti(int start, int step)
-{
-    return start + step/2;
-}
-
 /*Get the dti from the timebin*/
 inline inttime_t dti_from_timebin(int bin) {
     return bin ? (1 << bin) : 0;
@@ -269,7 +263,7 @@ apply_half_kick(void)
         /* current Kick time */
         inttime_t tistart = P[i].Ti_kick;
         /* half of a step */
-        inttime_t tiend = get_kick_ti(P[i].Ti_kick, dti);
+        inttime_t tiend = P[i].Ti_kick + dti / 2;
         /*This only changes particle i, so is thread-safe.*/
         do_the_short_range_kick(i, tistart, tiend);
     }
@@ -281,7 +275,7 @@ apply_PM_half_kick(void)
 {
     /*Always do a PM half-kick, because this should be called just after a PM step*/
     const inttime_t tistart = PM.Ti_kick;
-    const inttime_t tiend =  get_kick_ti(PM.Ti_kick, PM.length);
+    const inttime_t tiend =  PM.Ti_kick + PM.length / 2;
     /* Do long-range kick */
     do_the_long_range_kick(tistart, tiend);
     walltime_measure("/Timeline/HalfKick/Long");

--- a/timestep.h
+++ b/timestep.h
@@ -14,7 +14,7 @@ void timestep_allocate_memory(int MaxPart);
 int update_active_timebins(inttime_t next_kick);
 void rebuild_activelist(void);
 void set_global_time(double newtime);
-void find_timesteps_and_half_kick(void);
+void find_timesteps(void);
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 


### PR DESCRIPTION
Explicitly remember the current state of short range Kick and Drift.
of particles, and the current state of long range Kick and Drift.

This makes the logic in prediction cleaner (compensating difference
between drift and kick).

Move the first half kick before find time step, because it is finishing
the previous time step. The second half kick uses the new time step.

The code compiles, but I suspect there are bugs. 