### PR TITLE
Better local refine

### DIFF
--- a/domain.c
+++ b/domain.c
@@ -811,6 +811,7 @@ domain_toptree_garbage_collection(struct local_topnode_data * topTree, int start
     (*last_free) += 8;
     for(j = 0; j < 8; j ++) {
         topTree[newd + j] = topTree[oldd + j];
+        topTree[newd + j].Parent = start;
         domain_toptree_garbage_collection(topTree, newd + j, last_free);
     }
 }

--- a/domain.c
+++ b/domain.c
@@ -1090,8 +1090,8 @@ int domain_determineTopTree(struct local_topnode_data * topTree)
     walltime_measure("/Domain/DetermineTopTree/Misc");
 
     /* Watchout : must disgard proximity of particle type; this ordering is only required by LocalRefine */
-    //mpsort_mpi(LP, NumPart, sizeof(struct local_particle_data), mp_order_by_key, 8, NULL, MPI_COMM_WORLD);
-    qsort_openmp(LP, NumPart, sizeof(struct local_particle_data), order_by_key);
+
+    mpsort_mpi(LP, NumPart, sizeof(struct local_particle_data), mp_order_by_key, 8, NULL, MPI_COMM_WORLD);
 
     walltime_measure("/Domain/DetermineTopTree/Sort");
 

--- a/domain.h
+++ b/domain.h
@@ -8,10 +8,10 @@
 
 extern struct topnode_data
 {
-    peano_t Size;		/*!< number of Peano-Hilbert mesh-cells represented by top-level node */
     peano_t StartKey;		/*!< first Peano-Hilbert key in top-level node */
     int Daughter;			/*!< index of first daughter cell (out of 8) of top-level node */
-    int Leaf;			/*!< if the node is a leaf, this gives its index in topleaf_data */
+    short int Shift;    /*!< level = log 2 of number of Peano-Hilbert mesh-cells represented by top-level node */
+    int Leaf ;			/*!< if the node is a leaf, this gives its index in topleaf_data */
 } *TopNodes;
 
 extern struct topleaf_data {

--- a/forcetree.c
+++ b/forcetree.c
@@ -144,6 +144,8 @@ int force_tree_build(int npart)
  * tree we are currently at.
  * Returns a value between 0 and 7. If particles are very close,
  * the tree subnode is randomised.
+ *
+ * shift is the level of the subnode to be returned, not the level of the parent node.
  * */
 int get_subnode(const struct NODE * node, const int nodepos, const int p_i, const int shift, const morton_t *MortonKey)
 {
@@ -249,14 +251,14 @@ int force_tree_build_single(int npart)
         /*First find the Node for the TopLeaf */
 
         int shift;
-        int this = domain_get_topleaf_with_shift(P[i].Key, &shift);
-        this = TopLeaves[this].topnode;
+        int topleaf = domain_get_topleaf_with_shift(P[i].Key, &shift);
+        int this = TopLeaves[topleaf].treenode;
 
         /*Now walk the main tree*/
         while(1)
         {
             /*We will always start with an internal node: find the desired subnode.*/
-            const int subnode = get_subnode(&Nodes[this], this, i, shift, MortonKey);
+            const int subnode = get_subnode(&Nodes[this], this, i, shift - 3, MortonKey);
 
             shift -= 3;
 

--- a/system.c
+++ b/system.c
@@ -454,3 +454,9 @@ get_physmem_bytes()
     return 64 * 1024 * 1024;
 }
 
+int
+MPIU_Any(int condition, MPI_Comm comm)
+{
+    MPI_Allreduce(MPI_IN_PLACE, &condition, 1, MPI_INT, MPI_LOR, comm);
+    return condition;
+}

--- a/system.h
+++ b/system.h
@@ -19,6 +19,8 @@ void sumup_longs(int n, int64_t *src, int64_t *res);
 int64_t count_sum(int64_t countLocal);
 //int64_t count_to_offset(int64_t countLocal);
 
+int MPIU_Any(int condition, MPI_Comm comm);
+
 int MPI_Alltoallv_smart(void *sendbuf, int *sendcnts, int *sdispls,
         MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
         int *rdispls, MPI_Datatype recvtype, MPI_Comm comm);


### PR DESCRIPTION
This implements a drastically faster local refinement algorithm.

The main idea is to first build a full tree for a subsample of particles (current 1/16th). Then accurately count the cost and counts for each node in this tree quickly, and once. This accurate tree is then chopped off to produce the local refinement, such that each leave is smaller than the required granularity.

The secondary improvement is to avoid permuting the P data structure by the Key. We only need Key and Cost for each particle in most of the toptree meddling. Because the new data is much smaller, I required a global sorting with mpsort, this should improve the locality of the local trees, and improve the accuracy of the final merged tree.

The third improvement is to remove the poorly split logic between add_costs and merge_tree. The function is also better documented now.


The dm-only test case runs to redshift zero. 