### PR TITLE
Auto alltoall.

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -36,6 +36,7 @@ OBJECTS  =  \
 ICOBJECTS   = genic/main.o genic/power.o genic/allvars.o genic/params.o \
 		genic/zeldovich.o genic/save.o \
 		 petapm.o \
+		 system.o \
         paramset.o \
         utils-string.o \
 		 openmpsort.o \

--- a/allvars.c
+++ b/allvars.c
@@ -38,8 +38,6 @@ int64_t TotNumPart;
 int N_bh_slots;
 int N_sph_slots;
 
-gsl_rng *random_generator;	/*!< the random number generator used */
-
 /* variables for input/output , usually only used on process 0 */
 
 

--- a/exchange.c
+++ b/exchange.c
@@ -250,17 +250,17 @@ static int domain_exchange_once(int (*layoutfunc)(int p), int* toGo, int * toGoS
     if(N_bh_slots > All.MaxPartBh)
         endrun(787878, "Task=%d N_bh=%d All.MaxPartBh=%d\n", ThisTask, N_bh_slots, All.MaxPartBh);
 
-    MPI_Alltoallv_sparse(partBuf, count, offset, MPI_TYPE_PARTICLE,
+    MPI_Alltoallv_smart(partBuf, count, offset, MPI_TYPE_PARTICLE,
                  P, count_recv, offset_recv, MPI_TYPE_PARTICLE,
                  MPI_COMM_WORLD);
     walltime_measure("/Domain/exchange/alltoall");
 
-    MPI_Alltoallv_sparse(sphBuf, count_sph, offset_sph, MPI_TYPE_SPHPARTICLE,
+    MPI_Alltoallv_smart(sphBuf, count_sph, offset_sph, MPI_TYPE_SPHPARTICLE,
                  SphP, count_recv_sph, offset_recv_sph, MPI_TYPE_SPHPARTICLE,
                  MPI_COMM_WORLD);
     walltime_measure("/Domain/exchange/alltoall");
 
-    MPI_Alltoallv_sparse(bhBuf, count_bh, offset_bh, MPI_TYPE_BHPARTICLE,
+    MPI_Alltoallv_smart(bhBuf, count_bh, offset_bh, MPI_TYPE_BHPARTICLE,
                 BhP, count_recv_bh, offset_recv_bh, MPI_TYPE_BHPARTICLE,
                 MPI_COMM_WORLD);
     walltime_measure("/Domain/exchange/alltoall");

--- a/petapm.c
+++ b/petapm.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <stdint.h>
 /* do NOT use complex.h it breaks the code */
 
 #include "petapm.h"
@@ -10,6 +11,7 @@
 #include "mymalloc.h"
 #include "walltime.h"
 #include "endrun.h"
+#include "system.h"
 
 /* a layout is the communication object, represent 
  * pencil / cells exchanged  */
@@ -507,7 +509,7 @@ static void layout_exchange_pencils(struct Layout * L) {
         offset += L->NpSend[i];
     }
 
-    MPI_Alltoallv(
+    MPI_Alltoallv_smart(
             L->PencilSend, L->NpSend, L->DpSend, MPI_PENCIL,
             L->PencilRecv, L->NpRecv, L->DpRecv, MPI_PENCIL, 
             MPI_COMM_WORLD);
@@ -564,7 +566,7 @@ static void layout_build_and_exchange_cells_to_pfft(struct Layout * L) {
     }
 
     /* receive cells */
-    MPI_Alltoallv(
+    MPI_Alltoallv_smart(
             L->BufSend, L->NcSend, L->DcSend, MPI_DOUBLE,
             L->BufRecv, L->NcRecv, L->DcRecv, MPI_DOUBLE, 
             MPI_COMM_WORLD);
@@ -607,7 +609,7 @@ static void layout_build_and_exchange_cells_to_local(struct Layout * L) {
 
     /* exchange cells */
     /* notice the order is reversed from to_pfft */
-    MPI_Alltoallv(
+    MPI_Alltoallv_smart(
             L->BufRecv, L->NcRecv, L->DcRecv, MPI_DOUBLE, 
             L->BufSend, L->NcSend, L->DcSend, MPI_DOUBLE,
             MPI_COMM_WORLD);

--- a/system.c
+++ b/system.c
@@ -111,17 +111,11 @@ void write_pid_file(void)
 }
 #endif
 
+gsl_rng *random_generator;	/*!< the random number generator used */
 
 double RndTable[RNDTABLE];
 
-/*
-double get_random_number(unsigned int id)
-{
-  return RndTable[(id % RNDTABLE)];
-}
-*/
-
-double get_random_number(MyIDType id)
+double get_random_number(uint64_t id)
 {
   return RndTable[(int)(id % RNDTABLE)];
 }

--- a/system.h
+++ b/system.h
@@ -12,7 +12,7 @@ int cluster_get_num_hosts();
 int cluster_get_hostid();
 double get_physmem_bytes();
 
-double get_random_number(MyIDType id);
+double get_random_number(uint64_t id);
 void set_random_numbers(void);
 void sumup_large_ints(int n, int *src, int64_t *res);
 void sumup_longs(int n, int64_t *src, int64_t *res);

--- a/system.h
+++ b/system.h
@@ -29,6 +29,10 @@ int MPI_Alltoallv_sparse(void *sendbuf, int *sendcnts, int *sdispls,
         MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
         int *rdispls, MPI_Datatype recvtype, MPI_Comm comm);
 
+int MPI_Alltoallv_sparseI(void *sendbuf, int *sendcnts, int *sdispls,
+        MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
+        int *rdispls, MPI_Datatype recvtype, MPI_Comm comm);
+
 double timediff(double t0, double t1);
 double second(void);
 size_t sizemax(size_t a, size_t b);

--- a/treewalk.c
+++ b/treewalk.c
@@ -587,11 +587,11 @@ ev_communicate(void * sendbuf, void * recvbuf, size_t elsize, int import) {
     MPI_Type_commit(&type);
 
     if(import) {
-        MPI_Alltoallv_sparse(
+        MPI_Alltoallv_smart(
                 sendbuf, Recv_count, Recv_offset, type,
                 recvbuf, Send_count, Send_offset, type, MPI_COMM_WORLD);
     } else {
-        MPI_Alltoallv_sparse(
+        MPI_Alltoallv_smart(
                 sendbuf, Send_count, Send_offset, type,
                 recvbuf, Recv_count, Recv_offset, type, MPI_COMM_WORLD);
     }


### PR DESCRIPTION
This PR uses smart all to all in all places. In principle it shall make the code run a bit faster. But maybe not. The heuristics is to strike a balance between memory footprint of the MPI library and speed. Really should have been implemented inside MPI but different vendors have different philosophy in `MPI_Alltoallv`.