### PR TITLE
Use two versions of density(), and density_update()

### DIFF
--- a/init.c
+++ b/init.c
@@ -292,7 +292,7 @@ setup_smoothinglengths(int RestartSnapNum)
                     olddensity[i] = SPHP(i).EgyWtDensity;
                 }
             }
-            density();
+            density_update();
             badness = 0;
 
 #pragma omp parallel private(i)
@@ -331,6 +331,6 @@ setup_smoothinglengths(int RestartSnapNum)
     }
 
 #ifdef DENSITY_INDEPENDENT_SPH
-    density();
+    density_update();
 #endif //DENSITY_INDEPENDENT_SPH
 }

--- a/proto.h
+++ b/proto.h
@@ -4,7 +4,8 @@
 void allocate_memory(void);
 void begrun(int RestartFlag, int RestartSnapNum);
 
-void density(void);
+void density();
+void density_update();
 void energy_statistics(void);
 
 void grav_short_tree(void);


### PR DESCRIPTION
Replaces #98 

This one doesn't slow down at all because it doesn't introduce an additional tree walk every step.

It only helps to stablize the initialization iteration in pressure-entropy SPH. No other structural benefits from split smoothing from density. 

@sbird Does this look ok to you?

