### PR TITLE
Fix Node softenings

### DIFF
--- a/forcetree.h
+++ b/forcetree.h
@@ -18,6 +18,9 @@ extern struct NODE
         unsigned int InternalTopLevel :1; /* TopLevel and has a child which is also TopLevel*/
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
+        /* Stores if there are types with different softenings in the node.
+         * This is used to open the node if it matters, because
+         * there is no other way to tell where the types in the node are.*/
         unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
     } f;
     union


### PR DESCRIPTION
The current logic for force softenings in nodes is roughly this:

1) Check particle softening and maximum node softening
(If we have adaptive softening for gas particles, this affects what the softenings are)

2) Check whether the particle softening is less than the node softening. 
If they are the same, use the node. This in particular means that nodes 
are never opened if all softening lengths are identical.
3) Check whether MixedSofteningsInNode is also true. If it is, open the node. 
If it is not, use the node as is.

I believe the correct logic is wildly wrong, and will lead to unphysical particle 
coupling (which I have observed many times with the neutrino simulations).
If we are within the softening length of the node, we should always open the node.
The original author seems to have thought that if opening the node would not change 
the softening length, there is no point opening it. However, this is not true:
consider for example a particle close to a node containing two particles, 
equidistant between them, as so:

x  N  x

   P

If P is exactly 1 softening length from N, it is more than 1 softening length from both x's,
and the force it experiences may be quite different.

This branch implements logic where we always open a node if we find ourselves within 
the softening length. 

This should fix a real problem I was having with the neutrino simulations: 
I would observe large unphysical particle coupling, which disappeared when I made the neutrino
softening slightly larger. Even slightly larger was enough the nodes would almost 
always get opened for CDM particles, because nodes almost always contain both types.
Once the nodes are opened, the force on each particle differs more and the particle 
coupling is reduced.

This pull request removes checks 2 and 3, just opening the node if we are close to it. MixedSofteningsInNode is removed entirely.