### PR TITLE
Forcetree with a linked list.

### DIFF
--- a/allvars.h
+++ b/allvars.h
@@ -504,6 +504,7 @@ extern struct particle_data
 #ifdef BLACK_HOLES
         unsigned int Swallowed : 1; /* whether it is being swallowed */
 #endif
+        unsigned int SufferFromCoupling:1; /* whether it suffers from particle-coupling (nearest neighbour << gravity smoothing)*/
     };
 
     unsigned int PI; /* particle property index; used by BH. points to the BH property in BhP array.*/

--- a/allvars.h
+++ b/allvars.h
@@ -504,7 +504,9 @@ extern struct particle_data
 #ifdef BLACK_HOLES
         unsigned int Swallowed : 1; /* whether it is being swallowed */
 #endif
+#ifdef DEBUG
         unsigned int SufferFromCoupling:1; /* whether it suffers from particle-coupling (nearest neighbour << gravity smoothing)*/
+#endif
     };
 
     unsigned int PI; /* particle property index; used by BH. points to the BH property in BhP array.*/

--- a/forcetree.c
+++ b/forcetree.c
@@ -658,14 +658,16 @@ force_update_node_recursive(int no, int sib, int tail, const int firstnode, cons
 {
     /*Set NextNode for this node*/
     if(tail < firstnode && tail >= 0 && force_get_next_node(tail) != -1) {
-        abort();
+        endrun(2,"Particle %d with tail %d already has tail set: %d\n",no, tail, force_get_next_node(tail));
     }
     tail = force_set_next_node(tail, no, firstnode, lastnode);
 
-    if(no < firstnode || no >= lastnode) {
-        /* For particles and pseudo particles we have nothing to update; */
-        /* But the new tail is the last particle in the linked list. */
-
+    /*For pseudo particles, nothing to update (but nextnode is not yet set)*/
+    if(no >= lastnode)
+        return no;
+    /* For particles we have nothing to update; */
+    /* But the new tail is the last particle in the linked list. */
+    if(no < firstnode) {
         int next = no;
         while(next != -1) {
             no = next;

--- a/forcetree.c
+++ b/forcetree.c
@@ -309,6 +309,13 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
     int i;
     int nnext = firstnode;		/* index of first free node */
 
+    /*Minimum size of the node depends on the minimum of all force softenings*/
+    double minsoft = All.ForceSoftening[0];
+    for(i = 1; i<6; i++)
+        if((minsoft == 0 || minsoft > All.ForceSoftening[i]) && All.ForceSoftening[i] > 0)
+            minsoft = All.ForceSoftening[i];
+    const double minlen = 1.0e-3 * minsoft;
+
     /* create an empty root node  */
     {
         struct NODE *nfreep = &Nodes[nnext];	/* select first node */
@@ -414,8 +421,6 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
 
         /* Now we have something that isn't an internal node, and we have a lock on it,
          * so we know it won't change. We can place the particle! */
-
-        const double minlen = 1.0e-3 * All.ForceSoftening[P[i].Type];
 
         insert_internal_node(this, subnode, child, i, firstnode, lastnode, &nnext, &nnext_thread, &nrem_thread, minlen);
 

--- a/forcetree.c
+++ b/forcetree.c
@@ -336,6 +336,8 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
         if(nnext_thread >= lastnode-1)
             continue;
 
+        const double minlen = 1.0e-3 * All.ForceSoftening[P[i].Type];
+
         /*First find the Node for the TopLeaf */
 
         int this;
@@ -408,7 +410,6 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
             /*When we get here we have reached a leaf of the tree. We have an internal node in this,
              * with a full (positive) subnode in subnode, containing a real particle.
              * We split this node (making it an internal node) and try to add our particle to the new split node.*/
-            const double minlen = 1.0e-3 * All.ForceSoftening[1];
             insert_internal_node(this, subnode, child, i, firstnode, lastnode, &nnext, &nnext_thread, &nrem_thread, minlen);
         }
 #ifdef OPENMP_USE_SPINLOCK

--- a/forcetree.c
+++ b/forcetree.c
@@ -398,7 +398,7 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
          * so attach this particle.*/
         if(child < 0) {
             Father[i] = this;
-            #pragma omp atomic write
+
             Nodes[this].u.suns[subnode] = i;
 
             /* create a linked list of length 1 */

--- a/forcetree.c
+++ b/forcetree.c
@@ -223,7 +223,7 @@ int get_freenode(int * nnext, struct NodeCache *nc)
  * We add a new internal node at this subnode and try to add both the old and new particles to it.
  * Parent is assumed to be locked.*/
 int
-insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
+modify_internal_node(int parent, int subnode, int p_child, int p_toplace,
         const struct TreeBuilder tb, int *nnext, struct NodeCache *nc, double minlen, int *closepairs)
 {
     int ret = 0;
@@ -295,7 +295,7 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
         tb.Nodes[ninsert].u.suns[new_subnode] = p_toplace;
     } else {
         /* Otherwise recurse and create a new node*/
-        ret = insert_internal_node(ninsert, child_subnode, p_child, p_toplace, tb, nnext, nc, minlen, closepairs);
+        ret = modify_internal_node(ninsert, child_subnode, p_child, p_toplace, tb, nnext, nc, minlen, closepairs);
     }
 
     if (ninsert != parent) {
@@ -315,8 +315,8 @@ int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
     int nnext = tb.firstnode;		/* index of first free node */
 
     /*Minimum size of the node depends on the minimum of all force softenings*/
-    double minsoft = All.ForceSoftening[0];
-    for(i = 1; i<6; i++)
+    double minsoft = 0;
+    for(i = 0; i<6; i++)
         if((minsoft == 0 || minsoft > All.ForceSoftening[i]) && All.ForceSoftening[i] > 0)
             minsoft = All.ForceSoftening[i];
     const double minlen = 1.0e-3 * minsoft;
@@ -432,7 +432,7 @@ int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
         /* Now we have something that isn't an internal node, and we have a lock on it,
          * so we know it won't change. We can place the particle! */
 
-        insert_internal_node(this, subnode, child, i, tb, &nnext, &nc, minlen, &closepairs);
+        modify_internal_node(this, subnode, child, i, tb, &nnext, &nc, minlen, &closepairs);
 
         /* Add an explicit flush because we are not using openmp's critical sections */
         #pragma omp flush

--- a/forcetree.c
+++ b/forcetree.c
@@ -278,9 +278,10 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
                 ninsert, child_subnode, Nodes[ninsert].center[0], Nodes[ninsert].center[1], Nodes[ninsert].center[2], Nodes[ninsert].len);
         */
     }
-    if(too_small || Nodes[ninsert].u.suns[new_subnode] == -1) {
+
+    if(p_child < 0 || new_subnode != child_subnode || too_small) {
         Father[p_toplace] = ninsert;
-        force_set_next_node(p_toplace, Nodes[ninsert].u.suns[new_subnode], firstnode, lastnode);
+        force_set_next_node(p_toplace, too_small ? p_child : -1, firstnode, lastnode);
         Nodes[ninsert].u.suns[new_subnode] = p_toplace;
     } else {
         /* Otherwise recurse and create a new node*/
@@ -351,8 +352,6 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
         if(nnext_thread >= lastnode-1)
             continue;
 
-        const double minlen = 1.0e-3 * All.ForceSoftening[P[i].Type];
-
         /*First find the Node for the TopLeaf */
 
         int this;
@@ -410,6 +409,8 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
 
         /* Now we have something that isn't an internal node, and we have a lock on it,
          * so we know it won't change. We can place the particle! */
+
+        const double minlen = 1.0e-3 * All.ForceSoftening[P[i].Type];
 
         insert_internal_node(this, subnode, child, i, firstnode, lastnode, &nnext, &nnext_thread, &nrem_thread, minlen);
 

--- a/forcetree.c
+++ b/forcetree.c
@@ -687,12 +687,9 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
     }
     tail = force_set_next_node(tail, no, tb);
 
-    /*For pseudo particles, nothing to update (but nextnode is not yet set)*/
-    if(no >= tb.lastnode)
-        return no;
-    /* For particles we have nothing to update; */
+    /* For particles and pseudo particles we have nothing to update; */
     /* But the new tail is the last particle in the linked list. */
-    if(no < tb.firstnode) {
+    if(no < tb.firstnode || no >= tb.lastnode) {
         int next = no;
         while(next != -1) {
             no = next;

--- a/forcetree.c
+++ b/forcetree.c
@@ -226,8 +226,14 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
 {
     int ret = 0;
     int ninsert;
-    int child_subnode;
-    if(p_child >= 0) {
+    int child_subnode, new_subnode;
+    const int too_small = Nodes[parent].len < minlen;
+    if(p_child == -1 || too_small) {
+        ninsert = parent;
+        child_subnode = subnode;
+        new_subnode = subnode;
+    }
+    else {
         /* if we are here the node must be large enough, thus contain exactly one child. */
 #ifdef DEBUG
         if(force_get_next_node(p_child) != -1) {
@@ -253,18 +259,12 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
         /* The new leaf will replace p_child in the parent (done before return)
          * Re-attach that particle to the new leaf.*/
         child_subnode = get_subnode(nfreep, p_child);
+        new_subnode = get_subnode(nfreep, p_toplace);
 
         Father[p_child] = ninsert;
-        force_set_next_node(p_child, nfreep->u.suns[child_subnode], firstnode, lastnode);
         nfreep->u.suns[child_subnode] = p_child;
-    } else {
-        ninsert = parent;
-        child_subnode = subnode;
     }
 
-    int new_subnode = get_subnode(&Nodes[ninsert], p_toplace);
-
-    int too_small = Nodes[ninsert].len < minlen;
     /* If these target slot is empty or if the new node is too small.
      * Attach the new particle to the new slot. */
     if(too_small) {

--- a/forcetree.c
+++ b/forcetree.c
@@ -228,11 +228,15 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
     int ninsert;
     int child_subnode, new_subnode;
     const int too_small = Nodes[parent].len < minlen;
+    /* Just insert the particle if we have an empty spot.
+     * If the node is already too small, do not split it,
+     * but instead prepend the particle to a linked list.*/
     if(p_child == -1 || too_small) {
         ninsert = parent;
         child_subnode = subnode;
         new_subnode = subnode;
     }
+    /*We have two particles here, so create a new child node to store them both.*/
     else {
         /* if we are here the node must be large enough, thus contain exactly one child. */
 #ifdef DEBUG
@@ -281,6 +285,7 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
 
     if(p_child < 0 || new_subnode != child_subnode || too_small) {
         Father[p_toplace] = ninsert;
+        /*If the node is too small we prepend the particle to a short linked list.*/
         force_set_next_node(p_toplace, too_small ? p_child : -1, firstnode, lastnode);
         Nodes[ninsert].u.suns[new_subnode] = p_toplace;
     } else {
@@ -711,7 +716,7 @@ force_update_node_recursive(int no, int sib, int tail, const int firstnode, cons
         {
             /* nothing to be done here because the mass of the
              * pseudo-particle is still zero. The node attributes will be changed
-             * later when we exchange the psuedo-particles.
+             * later when we exchange the pseudo-particles.
              */
         }
         else if(p < lastnode && p >= firstnode) /* a tree node */

--- a/forcetree.c
+++ b/forcetree.c
@@ -242,7 +242,7 @@ modify_internal_node(int parent, int subnode, int p_child, int p_toplace,
     else {
         /* if we are here the node must be large enough, thus contain exactly one child. */
 #ifdef DEBUG
-        if(force_get_next_node(p_child) != -1) {
+        if(force_get_next_node(p_child, tb) != -1) {
             abort();
         }
 #endif
@@ -571,19 +571,19 @@ force_insert_pseudo_particles(const struct TreeBuilder tb)
 }
 
 int
-force_get_next_node(int no)
+force_get_next_node(int no, const struct TreeBuilder tb)
 {
-    if(no >= All.MaxPart && no < All.MaxPart + MaxNodes) {
+    if(no >= tb.firstnode && no < tb.lastnode) {
         /* internal node */
-        return Nodes[no].u.d.nextnode;
+        return tb.Nodes[no].u.d.nextnode;
     }
-    if(no < All.MaxPart) {
+    if(no < tb.firstnode) {
         /* Particle */
         return Nextnode[no];
     }
     else { //if(no >= All.MaxPart + MaxNodes) {
         /* Pseudo Particle */
-        return Nextnode[no - MaxNodes];
+        return Nextnode[no - (tb.lastnode - tb.firstnode)];
     }
 }
 
@@ -608,15 +608,15 @@ force_set_next_node(int no, int next, const struct TreeBuilder tb)
 }
 
 int
-force_get_prev_node(int no)
+force_get_prev_node(int no, const struct TreeBuilder tb)
 {
     if(no < All.MaxPart) {
         /* Particle */
         int t = Father[no];
-        int next = force_get_next_node(t);
+        int next = force_get_next_node(t, tb);
         while(next != no) {
             t = next;
-            next = force_get_next_node(t);
+            next = force_get_next_node(t, tb);
         }
         return t;
     } else {
@@ -682,8 +682,8 @@ int
 force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder tb)
 {
     /*Set NextNode for this node*/
-    if(tail < tb.firstnode && tail >= 0 && force_get_next_node(tail) != -1) {
-        endrun(2,"Particle %d with tail %d already has tail set: %d\n",no, tail, force_get_next_node(tail));
+    if(tail < tb.firstnode && tail >= 0 && force_get_next_node(tail, tb) != -1) {
+        endrun(2,"Particle %d with tail %d already has tail set: %d\n",no, tail, force_get_next_node(tail, tb));
     }
     tail = force_set_next_node(tail, no, tb);
 
@@ -696,7 +696,7 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
         int next = no;
         while(next != -1) {
             no = next;
-            next = force_get_next_node(next);
+            next = force_get_next_node(next, tb);
         }
         return no;
     }
@@ -757,7 +757,7 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
             int next = p;
             while(next != -1) {
                 add_particle_moment_to_node(&Nodes[no], &P[next]);
-                next = force_get_next_node(next);
+                next = force_get_next_node(next, tb);
             }
         }
     }

--- a/forcetree.c
+++ b/forcetree.c
@@ -229,10 +229,11 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
     int child_subnode;
     if(p_child >= 0) {
         /* if we are here the node must be large enough, thus contain exactly one child. */
+#ifdef DEBUG
         if(force_get_next_node(p_child) != -1) {
             abort();
         }
-
+#endif
         /* The parent is already a leaf, need to split */
         /* Get memory for an extra node from our cache.*/
         ninsert = get_freenode(nnext, nnext_thread, nrem_thread);
@@ -267,11 +268,15 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
     /* If these target slot is empty or if the new node is too small.
      * Attach the new particle to the new slot. */
     if(too_small) {
+        P[p_child].SufferFromCoupling = 1;
+        P[p_toplace].SufferFromCoupling = 1;
+        /*
         message(1,"Close particles: %d @ [%g, %g, %g] and %d @ [%g, %g, %g]. "
                 "Attached to node %d, subnode %d, at [%g, %g, %g] (len %g).\n",
                 p_toplace, P[p_toplace].Pos[0], P[p_toplace].Pos[1], P[p_toplace].Pos[2],
                 p_child, P[p_child].Pos[0], P[p_child].Pos[1], P[p_child].Pos[2],
                 ninsert, child_subnode, Nodes[ninsert].center[0], Nodes[ninsert].center[1], Nodes[ninsert].center[2], Nodes[ninsert].len);
+        */
     }
     if(too_small || Nodes[ninsert].u.suns[new_subnode] == -1) {
         Father[p_toplace] = ninsert;
@@ -340,6 +345,8 @@ int force_tree_create_nodes(const int firstnode, const int lastnode, const int n
 #endif
     for(i = 0; i < npart; i++)
     {
+        P[i].SufferFromCoupling = 0;
+
         /*Can't break from openmp for*/
         if(nnext_thread >= lastnode-1)
             continue;

--- a/forcetree.c
+++ b/forcetree.c
@@ -263,14 +263,21 @@ insert_internal_node(int parent, int subnode, int p_child, int p_toplace,
 
     int new_subnode = get_subnode(&Nodes[ninsert], p_toplace);
 
+    int too_small = Nodes[ninsert].len < minlen;
     /* If these target slot is empty or if the new node is too small.
      * Attach the new particle to the new slot. */
-    if(Nodes[ninsert].u.suns[new_subnode] == -1 || Nodes[ninsert].len < minlen) {
+    if(too_small) {
+        message(1,"Close particles: %d @ [%g, %g, %g] and %d @ [%g, %g, %g]. "
+                "Attached to node %d, subnode %d, at [%g, %g, %g] (len %g).\n",
+                p_toplace, P[p_toplace].Pos[0], P[p_toplace].Pos[1], P[p_toplace].Pos[2],
+                p_child, P[p_child].Pos[0], P[p_child].Pos[1], P[p_child].Pos[2],
+                ninsert, child_subnode, Nodes[ninsert].center[0], Nodes[ninsert].center[1], Nodes[ninsert].center[2], Nodes[ninsert].len);
+    }
+    if(too_small || Nodes[ninsert].u.suns[new_subnode] == -1) {
         Father[p_toplace] = ninsert;
         force_set_next_node(p_toplace, Nodes[ninsert].u.suns[new_subnode], firstnode, lastnode);
         Nodes[ninsert].u.suns[new_subnode] = p_toplace;
     } else {
-
         /* Otherwise recurse and create a new node*/
         ret = insert_internal_node(ninsert, child_subnode, p_child, p_toplace, firstnode, lastnode, nnext, nnext_thread, nrem_thread, minlen);
     }

--- a/forcetree.h
+++ b/forcetree.h
@@ -43,6 +43,17 @@ extern struct NODE
     *Nodes;			/*!< this is a pointer used to access the nodes which is shifted such that Nodes[All.MaxPart]
                       gives the first allocated node */
 
+/*Structure containing the Node pointer, and the first and last entries*/
+struct TreeBuilder {
+    /*Index of first internal node*/
+    int firstnode;
+    /*Index of first pseudo-particle node*/
+    int lastnode;
+    /*!< this is a pointer used to access the nodes which is shifted such that Nodes[firstnode]
+     *   gives the first allocated node */
+    struct NODE *Nodes; 
+};
+
 extern int MaxNodes;		/*!< maximum allowed number of internal nodes */
 
 /*Used in domain.c*/
@@ -64,7 +75,7 @@ int
 force_get_next_node(int no);
 
 int
-force_set_next_node(int no, int next, const int firstnode, const int lastnode);
+force_set_next_node(int no, int next, const struct TreeBuilder tb);
 
 #endif
 

--- a/forcetree.h
+++ b/forcetree.h
@@ -69,10 +69,10 @@ void   force_tree_free(void);
 void   dump_particles(void);
 
 int
-force_get_prev_node(int no);
+force_get_prev_node(int no, const struct TreeBuilder tb);
 
 int
-force_get_next_node(int no);
+force_get_next_node(int no, const struct TreeBuilder tb);
 
 int
 force_set_next_node(int no, int next, const struct TreeBuilder tb);

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -170,6 +170,8 @@ static int check_moments(const int firstnode, const int lastnode, const int nump
 static int check_tree(const int firstnode, const int nnodes, const int numpart)
 {
     int tot_empty = 0, nrealnode = 0, sevens = 0;
+    size_t tot_suffering = 0;
+
     for(int i=firstnode; i<nnodes+firstnode; i++)
     {
         struct NODE * pNode = &Nodes[i];
@@ -204,6 +206,7 @@ static int check_tree(const int firstnode, const int nnodes, const int numpart)
                 int suffering = P[child].SufferFromCoupling;
 
                 while(Father[child] == i) {
+                    tot_suffering += P[child].SufferFromCoupling;
                     P[child].PI += 1;
                     assert_int_equal(suffering, P[child].SufferFromCoupling);
                     /*Check in right quadrant*/
@@ -231,6 +234,7 @@ static int check_tree(const int firstnode, const int nnodes, const int numpart)
     {
         assert_int_equal(P[i].PI, 1);
     }
+    printf("Total suffering = %td\n", tot_suffering);
     printf("Tree filling factor: %g on %d nodes (wasted: %d seven empty: %d)\n", tot_empty/(8.*nrealnode), nrealnode, nnodes - nrealnode, sevens);
     return nrealnode;
 }

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -199,14 +199,22 @@ static int check_tree(const int firstnode, const int nnodes, const int numpart)
             }
             /*Particle*/
             else {
-                P[child].PI += 1;
-                /*Check in right quadrant*/
-                for(int k=0; k<3; k++) {
-                    if(j & (1<<k)) {
-                        assert_true(P[child].Pos[k] > pNode->center[k]);
+                /* if the first particle suffers, then all particles on the list
+                 * must be suffering from particle-coupling */
+                int suffering = P[child].SufferFromCoupling;
+
+                while(Father[child] == i) {
+                    P[child].PI += 1;
+                    assert_int_equal(suffering, P[child].SufferFromCoupling);
+                    /*Check in right quadrant*/
+                    for(int k=0; k<3; k++) {
+                        if(j & (1<<k)) {
+                            assert_true(P[child].Pos[k] > pNode->center[k]);
+                        }
+                        else
+                            assert_true(P[child].Pos[k] <= pNode->center[k]);
                     }
-                    else
-                        assert_true(P[child].Pos[k] <= pNode->center[k]);
+                    child = force_get_next_node(child);
                 }
             }
         }
@@ -359,7 +367,7 @@ static int setup_tree(void **state) {
     /*Particles should not be outside this*/
     All.BoxSize = 8;
     for(int i=0; i<6; i++)
-        All.ForceSoftening[i] = 0.001;
+        All.ForceSoftening[i] = 0.1;
     /*Set up the top-level domain grid*/
     /* The whole tree goes into one topnode.
      * Set up just enough of the TopNode structure that

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -170,7 +170,6 @@ static int check_moments(const int firstnode, const int lastnode, const int nump
 static int check_tree(const int firstnode, const int nnodes, const int numpart)
 {
     int tot_empty = 0, nrealnode = 0, sevens = 0;
-    size_t tot_suffering = 0;
 
     for(int i=firstnode; i<nnodes+firstnode; i++)
     {
@@ -203,12 +202,11 @@ static int check_tree(const int firstnode, const int nnodes, const int numpart)
             else {
                 /* if the first particle suffers, then all particles on the list
                  * must be suffering from particle-coupling */
-                int suffering = P[child].SufferFromCoupling;
-
-                while(Father[child] == i) {
-                    tot_suffering += P[child].SufferFromCoupling;
+                do {
                     P[child].PI += 1;
-                    assert_int_equal(suffering, P[child].SufferFromCoupling);
+                    if(Nextnode[child] > -1) {
+                        assert_int_equal(Father[child], Father[Nextnode[child]]);
+                    }
                     /*Check in right quadrant*/
                     for(int k=0; k<3; k++) {
                         if(j & (1<<k)) {
@@ -218,7 +216,7 @@ static int check_tree(const int firstnode, const int nnodes, const int numpart)
                             assert_true(P[child].Pos[k] <= pNode->center[k]);
                     }
                     child = force_get_next_node(child);
-                }
+                } while(child > -1);
             }
         }
         /*All nodes should have at least one thing in them:
@@ -234,7 +232,6 @@ static int check_tree(const int firstnode, const int nnodes, const int numpart)
     {
         assert_int_equal(P[i].PI, 1);
     }
-    printf("Total suffering = %td\n", tot_suffering);
     printf("Tree filling factor: %g on %d nodes (wasted: %d seven empty: %d)\n", tot_empty/(8.*nrealnode), nrealnode, nnodes - nrealnode, sevens);
     return nrealnode;
 }


### PR DESCRIPTION
This PR avoids randomization by putting all particles in a small node to a linked list. These particles are marked as 'SufferFromCoupling' particles; such that we can potentially count them during the run.