### PR TITLE
Wrong syncpoints

### DIFF
--- a/examples/travis/paramfile.gadget
+++ b/examples/travis/paramfile.gadget
@@ -2,7 +2,7 @@
 
 InitCondFile = output/IC
 OutputDir = output
-OutputList = 0.1,0.11
+OutputList = 0.1,0.11, 0.12
 SnapshotFileBase = snapshot
 
 Nmesh = 32
@@ -16,7 +16,7 @@ TimeLimitCPU = 43000 #= 8 hours
 
 #  Characteristics of run
 
-TimeMax = 0.11
+TimeMax = 0.12
 
 Omega0 = 0.2814      # Total matter density  (at z=0)
 OmegaLambda = 0.7186      # Cosmological constant (at z=0)

--- a/timebinmgr.c
+++ b/timebinmgr.c
@@ -52,7 +52,7 @@ setup_sync_points(void)
             /* requesting output on an existing entry, e.g. TimeInit or duplicated entry */
         } else {
             /* insert the item; */
-            memmove(&SyncPoints[j], &SyncPoints[j + 1],
+            memmove(&SyncPoints[j + 1], &SyncPoints[j],
                 sizeof(SyncPoints[0]) * (NSyncPoints - j));
             SyncPoints[j].loga = loga;
             NSyncPoints ++;

--- a/timebinmgr.c
+++ b/timebinmgr.c
@@ -24,12 +24,16 @@ setup_sync_points(void)
 {
     int i;
 
+    memset(&SyncPoints[0], -1, sizeof(SyncPoints[0]) * 8192);
+
     /* Set up first and last entry to SyncPoints; TODO we can insert many more! */
 
     SyncPoints[0].loga = log(All.TimeIC);
     SyncPoints[0].write_snapshot = 0; /* by default no output here. */
+    SyncPoints[0].write_fof = 0;
     SyncPoints[1].loga = log(All.TimeMax);
     SyncPoints[1].write_snapshot = 1;
+    SyncPoints[1].write_fof = 0;
 
     NSyncPoints = 2;
 


### PR DESCRIPTION
This PR may fix the issue  from landerson, #114  where the code crashes outputting from high redshifts. It is because of a silly typo of memmove, mixing source and dest, and as a result some syncpoints / output times are lost!