### PR TITLE
Fix genic

### DIFF
--- a/genic/power.c
+++ b/genic/power.c
@@ -156,7 +156,7 @@ void initialize_powerspectrum(void)
     }
     if(InputPowerRedshift >= 0) {
         double Dplus = GrowthFactor(InitTime, 1/(1+InputPowerRedshift));
-        Norm /= sqrt(Dplus);
+        Norm /= (Dplus * Dplus);
         message(0,"Growth factor to z=0: %g \n", Dplus);
     }
 


### PR DESCRIPTION
A wrong power of Dplus was being used in GenIC, making power spectra at z=99 a factor of 1000 too large!
This is the root cause of #114

Fixes #114.