### PR TITLE
Remove OldAcc and PM_Potential from struct particle_data

### DIFF
--- a/allvars.h
+++ b/allvars.h
@@ -524,8 +524,7 @@ extern struct particle_data
 
     MyFloat GravPM[3];		/* particle acceleration due to long-range PM gravity force */
 
-    MyFloat Potential;		/* gravitational potential. This is the total potential after gravtree is called. */
-    MyFloat PM_Potential;  /* Only used by PM. useless after pm */
+    MyFloat Potential;		/* gravitational potential. This is the total potential after gravtree+gravpm is called. */
 
     MyFloat StarFormationTime;		/*!< formation time of star particle: needed to tell when wind is active. */
 

--- a/allvars.h
+++ b/allvars.h
@@ -523,8 +523,6 @@ extern struct particle_data
     MyFloat GravAccel[3];  /* particle acceleration due to short-range gravity */
 
     MyFloat GravPM[3];		/* particle acceleration due to long-range PM gravity force */
-    MyFloat OldAcc;			/* magnitude of old gravitational force. Used in relative opening
-                              criterion, only used by gravtree cross time steps */
 
     MyFloat Potential;		/* gravitational potential. This is the total potential after gravtree is called. */
     MyFloat PM_Potential;  /* Only used by PM. useless after pm */

--- a/genic/power.c
+++ b/genic/power.c
@@ -231,7 +231,7 @@ double TopHatSigma2(double R)
 
   /* note: 500/R is here chosen as integration boundary (infinity) */
   gsl_integration_qags (&F, 0, 500. / R, 0, 1e-4,1000,w,&result, &abserr);
-  printf("gsl_integration_qng in TopHatSigma2. Result %g, error: %g, intervals: %lu\n",result, abserr,w->size);
+/*   printf("gsl_integration_qng in TopHatSigma2. Result %g, error: %g, intervals: %lu\n",result, abserr,w->size); */
   gsl_integration_workspace_free (w);
   return result;
 }

--- a/gravpm.c
+++ b/gravpm.c
@@ -56,7 +56,7 @@ void gravpm_force(void) {
     #pragma omp parallel for
     for(i = 0; i < NumPart; i++)
     {
-        P[i].GravPM[0] = P[i].GravPM[1] = P[i].GravPM[2] = P[i].PM_Potential = 0;
+        P[i].GravPM[0] = P[i].GravPM[1] = P[i].GravPM[2] = 0;
     }
     /*
      * we apply potential transfer immediately after the R2C transform,
@@ -372,7 +372,7 @@ static void force_z_transfer(int64_t k2, int kpos[3], pfft_complex * value) {
     force_transfer(kpos[2], value);
 }
 static void readout_potential(int i, double * mesh, double weight) {
-    P[i].PM_Potential += weight * mesh[0];
+    P[i].Potential += weight * mesh[0];
 }
 static void readout_force_x(int i, double * mesh, double weight) {
     P[i].GravPM[0] += weight * mesh[0];

--- a/gravshort.h
+++ b/gravshort.h
@@ -42,9 +42,6 @@ grav_short_postprocess(int i, TreeWalk * tw)
         pow(All.CP.Omega0 * 3 * All.CP.Hubble * All.CP.Hubble / (8 * M_PI * All.G), 1.0 / 3);
 
     P[i].Potential *= All.G;
-
-    P[i].Potential += P[i].PM_Potential;	/* add in long-range potential */
-
 }
 
 static void

--- a/gravshort.h
+++ b/gravshort.h
@@ -31,17 +31,9 @@ grav_short_haswork(int i, TreeWalk * tw)
 static void
 grav_short_postprocess(int i, TreeWalk * tw)
 {
-    int j;
-
-    double ax, ay, az;
-    ax = P[i].GravAccel[0] + P[i].GravPM[0] / All.G;
-    ay = P[i].GravAccel[1] + P[i].GravPM[1] / All.G;
-    az = P[i].GravAccel[2] + P[i].GravPM[2] / All.G;
-
-    P[i].OldAcc = sqrt(ax * ax + ay * ay + az * az);
-    for(j = 0; j < 3; j++)
-        P[i].GravAccel[j] *= All.G;
-
+    P[i].GravAccel[0] *= All.G;
+    P[i].GravAccel[1] *= All.G;
+    P[i].GravAccel[2] *= All.G;
     /* calculate the potential */
     /* remove self-potential */
     P[i].Potential += P[i].Mass / All.SofteningTable[P[i].Type];
@@ -62,7 +54,15 @@ grav_short_copy(int place, TreeWalkQueryGravShort * input, TreeWalk * tw)
 
     if(All.AdaptiveGravsoftForGas && P[place].Type == 0)
         input->Soft = P[place].Hsml;
-    input->OldAcc = P[place].OldAcc;
+    /*Compute old acceleration before we over-write things*/
+    double aold=0;
+    int i;
+    for(i = 0; i < 3; i++) {
+       double ax = P[place].GravAccel[i] + P[place].GravPM[i];
+       aold += ax*ax;
+    }
+
+    input->OldAcc = sqrt(aold)/All.G;
 
 }
 static void

--- a/run.c
+++ b/run.c
@@ -315,11 +315,26 @@ void compute_accelerations(int is_PM, int FirstStep)
 
     walltime_measure("/Misc");
 
+    /* The opening criterion for the gravtree
+     * uses the *total* gravitational acceleration
+     * from the last timestep, GravPM+GravAccel.
+     * So we must compute GravAccel for this timestep
+     * before gravpm_force() writes the PM acc. for
+     * this timestep to GravPM. Note initially both
+     * are zero and so the tree is opened maximally
+     * on the first timestep.*/
     grav_short_tree();
 
-    /* PM is after tree as we need GravPM
-     * from the last step to compute the opening
-     * angle in tree.*/
+    /* We use the total gravitational acc.
+     * to open the tree and total acc for the timestep.
+     * Note that any of (GravAccel, GravPM,
+     * HydroAccel) may change much faster than
+     * the total acc.
+     * We do the same as Gadget-2, but one could
+     * instead use short-range tree acc. only
+     * for opening angle or short-range timesteps,
+     * or include hydro in the opening angle.*/
+
     if(is_PM)
     {
         gravpm_force();
@@ -332,6 +347,8 @@ void compute_accelerations(int is_PM, int FirstStep)
     /* For the first timestep, we do tree force twice
      * to allow usage of relative opening
      * criterion for consistent accuracy.
+     * This happens after PM because we want to
+     * use the total acceleration for tree opening.
      */
     if(FirstStep)
         grav_short_tree();

--- a/run.c
+++ b/run.c
@@ -315,6 +315,11 @@ void compute_accelerations(int is_PM, int FirstStep)
 
     walltime_measure("/Misc");
 
+    grav_short_tree();
+
+    /* PM is after tree as we need GravPM
+     * from the last step to compute the opening
+     * angle in tree.*/
     if(is_PM)
     {
         gravpm_force();
@@ -330,8 +335,6 @@ void compute_accelerations(int is_PM, int FirstStep)
      */
     if(FirstStep)
         grav_short_tree();
-
-    grav_short_tree();
 
     if(NTotal[0] > 0)
     {

--- a/runtests.c
+++ b/runtests.c
@@ -22,7 +22,6 @@ char * GDB_format_particle(int i);
 
 SIMPLE_PROPERTY(GravAccel, P[i].GravAccel[0], float, 3)
 SIMPLE_PROPERTY(GravPM, P[i].GravPM[0], float, 3)
-SIMPLE_PROPERTY(OldAcc, P[i].OldAcc, float, 1)
 
 void runtests()
 {
@@ -31,7 +30,6 @@ void runtests()
     for(ptype = 0; ptype < 6; ptype++) {
         IO_REG(GravAccel,       "f4", 3, ptype);
         IO_REG(GravPM,       "f4", 3, ptype);
-        IO_REG(OldAcc,       "f4", 1, ptype);
     }
 
     gravpm_force();

--- a/timebinmgr.c
+++ b/timebinmgr.c
@@ -71,9 +71,9 @@ setup_sync_points(void)
         SyncPoints[i].ti = (i * 1L) << (TIMEBINS);
     }
 
-    for(i = 0; i < NSyncPoints; i++) {
-        message(1,"Out: %g %ld\n", exp(SyncPoints[i].loga), SyncPoints[i].ti);
-    }
+/*     for(i = 0; i < NSyncPoints; i++) { */
+/*         message(1,"Out: %g %ld\n", exp(SyncPoints[i].loga), SyncPoints[i].ti); */
+/*     } */
 }
 
 /*! this function returns the next output time that is in the future of


### PR DESCRIPTION
Following a suggestion by Yu Feng, we do not actually need OldAcc in the particle data. 
I was originally going to create a temporary array, but I realised that because it is only used by one half of the force equation, we don't need it at all. 

To ensure this gives the same result as the previous solver,  we must perform the tree gravity first and the PM gravity second: otherwise the current PM step over-writes the last one.

I was then able to combine PM_Potential with Potential. 
I could have combined GravPM and GravAccel, but they are too useful for debugging.