### PR TITLE
Fix time bin count

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -722,10 +722,16 @@ void blackhole_make_one(int index) {
     P[child].Type = 5;	/* make it a black hole particle */
 
     P[child].StarFormationTime = All.Time;
-    P[child].Mass = All.SeedBlackHoleMass;
-    P[index].Mass -= All.SeedBlackHoleMass;
+    /*Ensure that mass is conserved*/
+    double BHmass = All.SeedBlackHoleMass;
+    if(P[index].Mass <= All.SeedBlackHoleMass) {
+        P[index].IsGarbage = 1;
+        BHmass = P[index].Mass;
+    }
+    P[child].Mass = BHmass;
+    P[index].Mass -= BHmass;
     BHP(child).base.ID = P[child].ID;
-    BHP(child).Mass = All.SeedBlackHoleMass;
+    BHP(child).Mass = BHmass;
     BHP(child).Mdot = 0;
 
     /* It is important to initialize MinPotPos to the current position of 

--- a/density.c
+++ b/density.c
@@ -418,8 +418,9 @@ density_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DhsmlEgyDensityFactor *= -SPHP(i).DhsmlDensityFactor;
                 SPHP(i).EgyWtDensity /= EntPred;
             } else {
-                SPHP(i).DhsmlEgyDensityFactor=0;
-                SPHP(i).EgyWtDensity=0;
+                /*Use non-weighted densities for this*/
+                SPHP(i).DhsmlEgyDensityFactor=SPHP(i).DhsmlDensityFactor;
+                SPHP(i).EgyWtDensity=SPHP(i).Density;
             }
 #endif
 

--- a/density.c
+++ b/density.c
@@ -418,7 +418,9 @@ density_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DhsmlEgyDensityFactor *= -SPHP(i).DhsmlDensityFactor;
                 SPHP(i).EgyWtDensity /= EntPred;
             } else {
-                /*Use non-weighted densities for this*/
+                /* Use non-weighted densities for this.
+                 * This should never occur normally,
+                 * but will happen for every particle during init().*/
                 SPHP(i).DhsmlEgyDensityFactor=SPHP(i).DhsmlDensityFactor;
                 SPHP(i).EgyWtDensity=SPHP(i).Density;
             }

--- a/domain.c
+++ b/domain.c
@@ -656,7 +656,7 @@ domain_get_topleaf(const peano_t key) {
     return no;
 }
 
-/*! This function determines chich particles that are currently stored
+/*! This function determines which particles that are currently stored
  *  on the local CPU have to be moved off according to the domain
  *  decomposition.
  *

--- a/drift.c
+++ b/drift.c
@@ -128,7 +128,7 @@ static void real_drift_particle(int i, inttime_t ti1)
         while(P[i].Pos[j] <= 0) P[i].Pos[j] += All.BoxSize;
     }
     /* avoid recomputing them during layout and force tree build.*/
-    P[i].Key = PEANO(P[i].Pos);
+    P[i].Key = PEANO(P[i].Pos, All.BoxSize);
 
     if(P[i].Type == 0)
     {

--- a/exchange.c
+++ b/exchange.c
@@ -156,7 +156,7 @@ static int domain_exchange_once(int (*layoutfunc)(int p), int* toGo, int * toGoS
         }
         /*Check whether the domain exchange will succeed. If not, bail*/
         if(NumPart + count_get[j] - count_togo[j] > All.MaxPart){
-            message(1,"Too many %s for exchange: NumPart=%d count_get = %d count_togo=%d All.MaxPart=%d\n", NumPart, nn[j], count_get[j], count_togo[j], All.MaxPart);
+            message(1,"Too many %s for exchange: NumPart=%d count_get = %d count_togo=%d All.MaxPart=%d\n", nn[j], NumPart, count_get[j], count_togo[j], All.MaxPart);
             bad_exh = 1;
         }
     }

--- a/exchange.c
+++ b/exchange.c
@@ -124,9 +124,9 @@ static int domain_exchange_once(int (*layoutfunc)(int p), int* toGo, int * toGoS
 
     for(j=0; j<NSP; j++) {
         count[j] = ctmem+j*NTask;
-        offset[j] = ctmem + 4*NSP * NTask +j*NTask;
-        count_recv[j] = ctmem + 2*4*NSP * NTask +j*NTask;
-        offset_recv[j] = ctmem + 3*4*NSP * NTask +j*NTask;
+        offset[j] = ctmem + NSP * NTask +j*NTask;
+        count_recv[j] = ctmem + 2 * NSP * NTask +j*NTask;
+        offset_recv[j] = ctmem + 3 * NSP * NTask +j*NTask;
     }
 
     /*Build arrays*/

--- a/fof.c
+++ b/fof.c
@@ -981,8 +981,8 @@ fof_save_groups(int num)
 
     message(0, "Group catalogues saved. took = %g sec\n", timediff(t0, t1));
 
-    /* fof with IO will break the tree; rebuild it by using domain_maintain */
-    domain_maintain();
+    /* fof with IO will break the tree by changing particle order; rebuild it */
+    force_tree_rebuild();
 }
 
 /* FIXME: these shall goto the private member of secondary tree walk */

--- a/fofpetaio.c
+++ b/fofpetaio.c
@@ -67,7 +67,6 @@ void fof_save_particles(int num) {
     int ptype_offset[6]={0};
     int ptype_count[6]={0};
 
-    /*This assumes particles are sorted by type*/
     petaio_build_selection(selection, ptype_offset, ptype_count, NumPart, fof_petaio_select_func);
 
     /*Sort each type individually*/

--- a/garbage.c
+++ b/garbage.c
@@ -41,7 +41,7 @@ int domain_fork_particle(int parent) {
      * if the parent is active the child should also be active.
      * Stars must always be active on formation, but
      * BHs need not be: a halo can be seeded when the particle in question is inactive.*/
-    if(is_timebin_active(P[parent].TimeBin)) {
+    if(is_timebin_active(P[parent].TimeBin, All.Ti_Current)) {
         int childactive = atomic_fetch_and_add(&NumActiveParticle, 1);
         ActiveParticle[childactive] = child;
     }

--- a/garbage.c
+++ b/garbage.c
@@ -112,10 +112,6 @@ domain_all_garbage_collection()
     for(i = 0; i < NumPart; i++)
         if(P[i].IsGarbage)
         {
-            TimeBinCount[P[i].TimeBin]--;
-
-            TimeBinCountType[P[i].Type][P[i].TimeBin]--;
-
             P[i] = P[NumPart - 1];
 
             NumPart--;

--- a/hydra.c
+++ b/hydra.c
@@ -38,7 +38,7 @@ typedef struct {
     MyFloat Pressure;
     MyFloat F1;
     MyFloat DhsmlDensityFactor;
-    int Timestep;
+    signed char TimeBin;
 
 } TreeWalkQueryHydro;
 
@@ -144,7 +144,7 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
 #endif
 
     input->Pressure = PressurePred(place);
-    input->Timestep = (P[place].TimeBin ? (1 << P[place].TimeBin) : 0);
+    input->TimeBin = P[place].TimeBin;
     /* calculation of F1 */
     soundspeed_i = sqrt(GAMMA * input->Pressure / SPHP(place).EOMDensity);
     input->F1 = fabs(SPHP(place).DivVel) /
@@ -291,8 +291,7 @@ hydro_ngbiter(
 
 #ifndef NOVISCOSITYLIMITER
             /*XXX: why is this dloga ?*/
-            double dloga =
-                2 * IMAX(I->Timestep, get_dloga_for_bin(P[other].TimeBin));
+            double dloga = 2 * get_dloga_for_bin(IMAX(I->TimeBin, P[other].TimeBin));
             if(dloga > 0 && (dwk_i + dwk_j) < 0)
             {
                 if((I->Mass + P[other].Mass) > 0) {

--- a/init.c
+++ b/init.c
@@ -89,7 +89,7 @@ void init(int RestartSnapNum)
             BHP(i).Mass = All.SeedBlackHoleMass;
         }
 #endif
-        P[i].Key = PEANO(P[i].Pos);
+        P[i].Key = PEANO(P[i].Pos, All.BoxSize);
 
         if(P[i].Type != 0) continue;
         for(j = 0; j < 3; j++)

--- a/init.c
+++ b/init.c
@@ -122,7 +122,7 @@ void init(int RestartSnapNum)
 
     domain_decompose_full();	/* do initial domain decomposition (gives equal numbers of particles) */
 
-    rebuild_activelist();
+    rebuild_activelist(0);
 
     setup_smoothinglengths(RestartSnapNum);
 }

--- a/peano.h
+++ b/peano.h
@@ -15,6 +15,7 @@ morton_t morton_key(int x, int y, int z, int bits);
 
 static inline peano_t PEANO(double *Pos, double BoxSize)
 {
+    /*No reason known for the Box/2000 and 1.001 factors*/
     const double DomainFac = 1.0 / (BoxSize*1.001) * (((peano_t) 1) << (BITS_PER_DIMENSION));
     const double spos[3] = {Pos[0] + BoxSize/2000, Pos[1] + BoxSize/2000, Pos[2] + BoxSize/2000};
     return peano_hilbert_key(spos[0]*DomainFac, spos[1]*DomainFac, spos[2]*DomainFac, BITS_PER_DIMENSION);

--- a/peano.h
+++ b/peano.h
@@ -10,12 +10,17 @@ typedef uint64_t morton_t;
 #define  BITS_PER_DIMENSION 21	/* for Peano-Hilbert order. Note: Maximum is 10 to fit in 32-bit integer ! */
 #define  PEANOCELLS (((peano_t)1)<<(3*BITS_PER_DIMENSION))
 
-#define DomainFac(len) ( 1.0 / (len) * (((peano_t) 1) << (BITS_PER_DIMENSION)))
+peano_t peano_hilbert_key(int x, int y, int z, int bits);
+morton_t morton_key(int x, int y, int z, int bits);
 
-#define PEANO(Pos) peano_hilbert_key((int) ((Pos[0] + All.BoxSize/2000) * DomainFac(All.BoxSize*1.001)), \
-        (int) ((Pos[1] + All.BoxSize/2000) * DomainFac(All.BoxSize*1.001)), \
-        (int) ((Pos[2] + All.BoxSize/2000) * DomainFac(All.BoxSize*1.001)), \
-        BITS_PER_DIMENSION)
+static inline peano_t PEANO(double *Pos, double BoxSize)
+{
+    const double DomainFac = 1.0 / (BoxSize*1.001) * (((peano_t) 1) << (BITS_PER_DIMENSION));
+    const double spos[3] = {Pos[0] + BoxSize/2000, Pos[1] + BoxSize/2000, Pos[2] + BoxSize/2000};
+    return peano_hilbert_key(spos[0]*DomainFac, spos[1]*DomainFac, spos[2]*DomainFac, BITS_PER_DIMENSION);
+}
+
+#define DomainFac(len) ( 1.0 / (len) * (((peano_t) 1) << (BITS_PER_DIMENSION)))
 
 #define MORTON(Pos) morton_key((int) ((Pos[0] + All.BoxSize/2000) * DomainFac(All.BoxSize*1.001)), \
         (int) ((Pos[1] + All.BoxSize/2000) * DomainFac(All.BoxSize*1.001)), \
@@ -25,7 +30,5 @@ typedef uint64_t morton_t;
 void mysort_peano(void *b, size_t n, size_t s, int (*cmp) (const void *, const void *));
 
 void init_peano_map(void);
-peano_t peano_hilbert_key(int x, int y, int z, int bits);
-morton_t morton_key(int x, int y, int z, int bits);
 
 #endif

--- a/run.c
+++ b/run.c
@@ -218,7 +218,7 @@ void run(void)
         /* more steps to go. */
 
         /* assign new timesteps to the active particles, now that we know they have synched TiKick and TiDrift */
-        minTimeBin = find_timesteps();
+        find_timesteps(&minTimeBin);
 
         /* Update velocity to the new step, with the newly computed step size */
         apply_half_kick();

--- a/run.c
+++ b/run.c
@@ -150,9 +150,7 @@ void run(void)
             domain_maintain();
         }
 
-        update_active_timebins(All.Ti_Current);
-
-        rebuild_activelist();
+        rebuild_activelist(All.Ti_Current);
 
         print_timebin_statistics(NumCurrentTiStep);
 

--- a/run.c
+++ b/run.c
@@ -433,16 +433,17 @@ void every_timestep_stuff(int NumCurrentTiStep)
     int64_t tot_count_type[6][TIMEBINS] = {0};
     int64_t tot_num_force = 0;
 
-    sumup_large_ints(TIMEBINS, TimeBinCount, tot_count);
     for(i = 0; i < 6; i ++) {
         sumup_large_ints(TIMEBINS, TimeBinCountType[i], tot_count_type[i]);
     }
-    int NumForce = 0;
+
     for(i = 0; i<TIMEBINS; i++) {
+        int j;
+        for(j=0; j<6; j++)
+            tot_count[i] += tot_count_type[j][i];
         if(is_timebin_active(i))
-            NumForce += TimeBinCount[i];
+            tot_num_force += tot_count[i];
     }
-    sumup_large_ints(1, &NumForce, &tot_num_force);
 
     /* let's update Tot counts in one place tot variables;
      * at this point there can still be holes in SphP

--- a/run.c
+++ b/run.c
@@ -42,7 +42,6 @@ static enum ActionType human_interaction(double lastPM, double TimeLastOutput);
 static int should_we_timeout(double TimelastPM);
 static void compute_accelerations(int is_PM, int FirstStep);
 static void update_IO_params(const char * ioctlfname);
-static void every_timestep_stuff(int NumCurrentTiStep);
 static void write_cpu_log(int NumCurrentTiStep);
 
 void run(void)
@@ -155,7 +154,9 @@ void run(void)
 
         rebuild_activelist();
 
-        every_timestep_stuff(NumCurrentTiStep);	/* write some info to log-files */
+        print_timebin_statistics(NumCurrentTiStep);
+
+        set_random_numbers();
 
         /* update force to Ti_Current */
         compute_accelerations(is_PM, NumCurrentTiStep == 0);
@@ -418,88 +419,6 @@ int should_we_timeout(double TimeLastPM)
         return 1;
     }
     return 0;
-}
-
-/*! This routine writes one line for every timestep.
- * FdCPU the cumulative cpu-time consumption in various parts of the
- * code is stored.
- */
-void every_timestep_stuff(int NumCurrentTiStep)
-{
-    double z;
-    int i;
-    int64_t tot = 0, tot_type[6] = {0};
-    int64_t tot_count[TIMEBINS] = {0};
-    int64_t tot_count_type[6][TIMEBINS] = {0};
-    int64_t tot_num_force = 0;
-
-    for(i = 0; i < 6; i ++) {
-        sumup_large_ints(TIMEBINS, TimeBinCountType[i], tot_count_type[i]);
-    }
-
-    for(i = 0; i<TIMEBINS; i++) {
-        int j;
-        for(j=0; j<6; j++)
-            tot_count[i] += tot_count_type[j][i];
-        if(is_timebin_active(i))
-            tot_num_force += tot_count[i];
-    }
-
-    /* let's update Tot counts in one place tot variables;
-     * at this point there can still be holes in SphP
-     * because rearrange_particle_squence is not called yet.
-     * but anywaysTotN_sph variables are not well defined and
-     * not used any places but printing.
-     *
-     * we shall just say they we sync these variables right after gravity
-     * calculation in every timestep.
-     * */
-
-    char extra[1024] = {0};
-
-    if(is_PM_timestep(All.Ti_Current))
-        strcat(extra, "PM-Step");
-
-    z = 1.0 / (All.Time) - 1;
-    message(0, "Begin Step %d, Time: %g, Redshift: %g, Nf = %014ld, Systemstep: %g, Dloga: %g, status: %s\n",
-                NumCurrentTiStep, All.Time, z, tot_num_force,
-                All.TimeStep, log(All.Time) - log(All.Time - All.TimeStep),
-                extra);
-
-    int64_t TotNumPart = 0;
-    for(i = 0; i < 6; i ++) TotNumPart += NTotal[i];
-
-    message(0, "TotNumPart: %013ld SPH %013ld BH %010ld STAR %013ld \n",
-                TotNumPart, NTotal[0], NTotal[5], NTotal[4]);
-    message(0,     "Occupied: % 12ld % 12ld % 12ld % 12ld % 12ld % 12ld dt\n", 0L, 1L, 2L, 3L, 4L, 5L);
-
-    for(i = TIMEBINS - 1;  i >= 0; i--) {
-        if(tot_count[i] == 0) continue;
-        message(0, " %c bin=%2d % 12ld % 12ld % 12ld % 12ld % 12ld % 12ld %6g\n",
-                is_timebin_active(i) ? 'X' : ' ',
-                i,
-                tot_count_type[0][i],
-                tot_count_type[1][i],
-                tot_count_type[2][i],
-                tot_count_type[3][i],
-                tot_count_type[4][i],
-                tot_count_type[5][i],
-                get_dloga_for_bin(i));
-
-        if(is_timebin_active(i))
-        {
-            tot += tot_count[i];
-            int ptype;
-            for(ptype = 0; ptype < 6; ptype ++) {
-                tot_type[ptype] += tot_count_type[ptype][i];
-            }
-        }
-    }
-    message(0,     "               -----------------------------------\n");
-    message(0,     "Total:    % 12ld % 12ld % 12ld % 12ld % 12ld % 12ld  Sum:% 14ld\n",
-        tot_type[0], tot_type[1], tot_type[2], tot_type[3], tot_type[4], tot_type[5], tot);
-
-    set_random_numbers();
 }
 
 void write_cpu_log(int NumCurrentTiStep)

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -721,9 +721,6 @@ static int make_particle_star(int i) {
 
         P[i].Type = 4;
 
-        TimeBinCountType[0][P[i].TimeBin]--;
-        TimeBinCountType[4][P[i].TimeBin]++;
-
         newstar = i;
     }
     else
@@ -739,7 +736,6 @@ static int make_particle_star(int i) {
         NLocal[4] ++;
         newstar = child;
 
-        TimeBinCountType[4][P[i].TimeBin]++;
         stars_spawned++;
     }
 

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -247,7 +247,7 @@ static void do_tree_test(const int numpart, const struct TreeBuilder tb)
     int i;
     #pragma omp parallel for
     for(i=0; i<numpart; i++) {
-        P[i].Key = PEANO(P[i].Pos);
+        P[i].Key = PEANO(P[i].Pos, All.BoxSize);
         P[i].Mass = 1;
     }
     qsort(P, numpart, sizeof(struct particle_data), order_by_type_and_key);

--- a/timestep.c
+++ b/timestep.c
@@ -38,7 +38,6 @@ static inline inttime_t dti_from_timebin(int bin) {
 int NumActiveParticle;
 int *ActiveParticle;
 
-int TimeBinCount[TIMEBINS];
 int TimeBinCountType[6][TIMEBINS];
 int TimeBinActive[TIMEBINS];
 
@@ -727,8 +726,6 @@ void rebuild_activelist(void)
 {
     int i;
 
-
-    memset(TimeBinCount, 0, TIMEBINS*sizeof(int));
     memset(TimeBinCountType, 0, 6*TIMEBINS*sizeof(int));
 
     NumActiveParticle = 0;
@@ -742,7 +739,6 @@ void rebuild_activelist(void)
             ActiveParticle[NumActiveParticle] = i;
             NumActiveParticle++;
         }
-        TimeBinCount[bin]++;
         TimeBinCountType[P[i].Type][bin]++;
     }
 }

--- a/timestep.c
+++ b/timestep.c
@@ -38,7 +38,7 @@ static inline inttime_t dti_from_timebin(int bin) {
 int NumActiveParticle;
 int *ActiveParticle;
 
-static int TimeBinCountType[6][TIMEBINS];
+static int TimeBinCountType[6][TIMEBINS+1];
 
 void timestep_allocate_memory(int MaxPart)
 {
@@ -732,7 +732,7 @@ int rebuild_activelist(inttime_t Ti_Current)
 {
     int i;
 
-    memset(TimeBinCountType, 0, 6*TIMEBINS*sizeof(int));
+    memset(TimeBinCountType, 0, 6*(TIMEBINS+1)*sizeof(int));
     NumActiveParticle = 0;
 
     for(i = 0; i < NumPart; i++)
@@ -758,15 +758,15 @@ void print_timebin_statistics(int NumCurrentTiStep)
     double z;
     int i;
     int64_t tot = 0, tot_type[6] = {0};
-    int64_t tot_count[TIMEBINS] = {0};
-    int64_t tot_count_type[6][TIMEBINS] = {0};
+    int64_t tot_count[TIMEBINS+1] = {0};
+    int64_t tot_count_type[6][TIMEBINS+1] = {0};
     int64_t tot_num_force = 0;
 
     for(i = 0; i < 6; i ++) {
-        sumup_large_ints(TIMEBINS, TimeBinCountType[i], tot_count_type[i]);
+        sumup_large_ints(TIMEBINS+1, TimeBinCountType[i], tot_count_type[i]);
     }
 
-    for(i = 0; i<TIMEBINS; i++) {
+    for(i = 0; i<TIMEBINS+1; i++) {
         int j;
         for(j=0; j<6; j++)
             tot_count[i] += tot_count_type[j][i];
@@ -792,7 +792,7 @@ void print_timebin_statistics(int NumCurrentTiStep)
                 TotNumPart, NTotal[0], NTotal[5], NTotal[4]);
     message(0,     "Occupied: % 12ld % 12ld % 12ld % 12ld % 12ld % 12ld dt\n", 0L, 1L, 2L, 3L, 4L, 5L);
 
-    for(i = TIMEBINS - 1;  i >= 0; i--) {
+    for(i = TIMEBINS;  i >= 0; i--) {
         if(tot_count[i] == 0) continue;
         message(0, " %c bin=%2d % 12ld % 12ld % 12ld % 12ld % 12ld % 12ld %6g\n",
                 is_timebin_active(i, All.Ti_Current) ? 'X' : ' ',

--- a/timestep.c
+++ b/timestep.c
@@ -397,21 +397,32 @@ sph_VelPred(int i, double * VelPred)
     }
 }
 
+/*Helper function for predicting the entropy*/
+static inline double _EntPred(int i)
+{
+    const double Fentr = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);
+    double epred = SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr;
+    /*This mirrors the entropy limiter in do_the_short_range_kick*/
+    if(epred < 0.5 * SPHP(i).Entropy)
+        epred = 0.5 * SPHP(i).Entropy;
+    return epred;
+}
+
 /* This gives the predicted entropy at the particle Kick timestep
  * for the density independent SPH code.
  * Watchout: with kddk, when the second k is applied, Ti_kick < Ti_drift. */
 double
 EntropyPred(int i)
 {
-    const double Fentr = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);
-    return pow(SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr, 1/GAMMA);
+    double epred = _EntPred(i);
+    return pow(epred, 1/GAMMA);
 }
 
 double
 PressurePred(int i)
 {
-    const double Fentr = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);
-    return (SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr) * pow(SPHP(i).EOMDensity, GAMMA);
+    double epred = _EntPred(i);
+    return epred * pow(SPHP(i).EOMDensity, GAMMA);
 }
 
 double

--- a/timestep.h
+++ b/timestep.h
@@ -14,7 +14,7 @@ void timestep_allocate_memory(int MaxPart);
 int update_active_timebins(inttime_t next_kick);
 void rebuild_activelist(void);
 void set_global_time(double newtime);
-void find_timesteps(void);
+int find_timesteps(void);
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 
@@ -25,7 +25,7 @@ void sph_VelPred(int i, double * VelPred);
 double EntropyPred(int i);
 double PressurePred(int i);
 
-inttime_t find_next_kick(inttime_t Ti_Current);
+inttime_t find_next_kick(inttime_t Ti_Current, int minTimeBin);
 
 void init_timebins(double TimeInit);
 

--- a/timestep.h
+++ b/timestep.h
@@ -11,7 +11,7 @@ void timestep_allocate_memory(int MaxPart);
 int update_active_timebins(inttime_t next_kick);
 void rebuild_activelist(void);
 void set_global_time(double newtime);
-int find_timesteps(void);
+int find_timesteps(int * MinTimeBin);
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 

--- a/timestep.h
+++ b/timestep.h
@@ -8,15 +8,14 @@ extern int NumActiveParticle;
 extern int *ActiveParticle;
 
 void timestep_allocate_memory(int MaxPart);
-int update_active_timebins(inttime_t next_kick);
-void rebuild_activelist(void);
+int rebuild_activelist(inttime_t ti_current);
 void set_global_time(double newtime);
 int find_timesteps(int * MinTimeBin);
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 
 void print_timebin_statistics(int NumCurrentTiStep);
-int is_timebin_active(int i);
+int is_timebin_active(int i, inttime_t current);
 void set_timebin_active(binmask_t mask);
 
 void sph_VelPred(int i, double * VelPred);

--- a/timestep.h
+++ b/timestep.h
@@ -7,8 +7,6 @@ set in run.c: find_next_sync_point_and_drift*/
 extern int NumActiveParticle;
 extern int *ActiveParticle;
 
-extern int TimeBinCountType[6][TIMEBINS];
-
 void timestep_allocate_memory(int MaxPart);
 int update_active_timebins(inttime_t next_kick);
 void rebuild_activelist(void);
@@ -17,6 +15,7 @@ int find_timesteps(void);
 void apply_half_kick(void);
 void apply_PM_half_kick(void);
 
+void print_timebin_statistics(int NumCurrentTiStep);
 int is_timebin_active(int i);
 void set_timebin_active(binmask_t mask);
 

--- a/timestep.h
+++ b/timestep.h
@@ -7,7 +7,6 @@ set in run.c: find_next_sync_point_and_drift*/
 extern int NumActiveParticle;
 extern int *ActiveParticle;
 
-extern int TimeBinCount[TIMEBINS];
 extern int TimeBinCountType[6][TIMEBINS];
 
 void timestep_allocate_memory(int MaxPart);


### PR DESCRIPTION
We found that TimeBinCount was not updated correctly in domain exchange: it was decremented for particles leaving, but not incremented for particles arriving. It was also not incremented correctly in sfr and black hole. Normally this did not matter, because rebuild_activelist was called after domain, but during FoF particles are exchanged (then returned) and rebuild_activelist is not called.

I considered a fix involving updating the TimeBinCount, but I found a simpler solution was just to avoid the need to keep it up to date. Now it is used only for printing counts just after domain. The smallest timebin is returned by find_timestep. This avoids a number of atomic updates in openmp code.

Also do not do domain_maintain after FoF: it always exchanged zero particles.