### PR TITLE
save UsePeculiarVelocity in header files.

### DIFF
--- a/examples/travis/paramfile.genic
+++ b/examples/travis/paramfile.genic
@@ -28,7 +28,9 @@ InputPowerRedshift = 9.0
 InputSpectrum_UnitLength_in_cm = 3.085678e24                     # defines length unit of tabulated
                                                                    # input spectrum in cm/h. 
                                                 # Note: This can be chosen different from UnitLength_in_cm
-    
+
+UsePeculiarVelocity = 1  # Use peculiar velocity like FastPM
+
 PrimordialIndex = 0.971      # may be used to rebuild the primordial power
 
 Seed = 181170    #  seed for IC-generator

--- a/genic/params.c
+++ b/genic/params.c
@@ -39,7 +39,7 @@ create_parameters()
     param_declare_double(ps, "MaxMemSizePerNode", OPTIONAL, 0.6 * get_physmem_bytes() / (1024 * 1024), "");
     param_declare_double(ps, "CMBTemperature", OPTIONAL, 2.7255, "CMB temperature in K");
     param_declare_double(ps, "RadiationOn", OPTIONAL, 1, "Include radiation in the background.");
-    param_declare_int(ps, "UsePeculiarVelocity", OPTIONAL, 0, "Write a IC similiar to a FastPM output");
+    param_declare_int(ps, "UsePeculiarVelocity", OPTIONAL, 0, "Set up an run that uses Peculiar Velocity in IO");
     param_declare_double(ps, "Sigma8", OPTIONAL, -1, "Renormalise Sigma8 to this number if positive");
     param_declare_int(ps, "InputPowerRedshift", OPTIONAL, 0, "Redshift at which the input power is. Power spectrum will be rescaled to the initial redshift. Negative disables rescaling.");
     param_declare_double(ps, "PrimordialIndex", OPTIONAL, 0.971, "Tilting power, ignored for tabulated input.");

--- a/genic/save.c
+++ b/genic/save.c
@@ -125,6 +125,7 @@ void saveheader(BigFile * bf) {
             (big_block_set_attr(&bheader, "Time", &InitTime, "f8", 1)) ||
             (big_block_set_attr(&bheader, "Redshift", &redshift, "f8", 1)) ||
             (big_block_set_attr(&bheader, "BoxSize", &Box, "f8", 1)) ||
+            (big_block_set_attr(&bheader, "UsePeculiarVelocity", &UsePeculiarVelocity, "i4", 1)) ||
             (big_block_set_attr(&bheader, "OmegaM", &CP.Omega0, "f8", 1)) ||
             (big_block_set_attr(&bheader, "OmegaB", &CP.OmegaBaryon, "f8", 1)) ||
             (big_block_set_attr(&bheader, "OmegaL", &CP.OmegaLambda, "f8", 1)) ||

--- a/param.c
+++ b/param.c
@@ -185,8 +185,6 @@ create_gadget_parameter_set()
     param_declare_int(ps, "CoolingOn", REQUIRED, 0, "Enables cooling");
     param_declare_double(ps, "UVRedshiftThreshold", OPTIONAL, -1.0, "Earliest Redshift that UV background is enabled. This modulates UVFluctuation and TreeCool globally. Default -1.0 means no modulation.");
 
-    param_declare_int(ps, "UsePeculiarVelocity", OPTIONAL, 0, "Mimic the Input and outputs of FastPM. Use peculiar velocity in IO, and Mpc/h units by default.");
-
     param_declare_int(ps, "HydroOn", REQUIRED, 1, "Enables hydro force");
     param_declare_int(ps, "DensityOn", OPTIONAL, 1, "Enables SPH density computation.");
     param_declare_int(ps, "TreeGravOn", OPTIONAL, 1, "Enables tree gravity");

--- a/param.c
+++ b/param.c
@@ -383,7 +383,7 @@ void read_parameter_file(char *fname)
         All.MaxNumNgbDeviation = param_get_double(ps, "MaxNumNgbDeviation");
 
         All.IO.BytesPerFile = param_get_int(ps, "BytesPerFile");
-        All.IO.UsePeculiarVelocity = param_get_int(ps, "UsePeculiarVelocity");
+        All.IO.UsePeculiarVelocity = 0; /* Will be set by the Initial Condition File */
         All.IO.NumWriters = param_get_int(ps, "NumWriters");
         All.IO.MinNumWriters = param_get_int(ps, "MinNumWriters");
         All.IO.WritersPerFile = param_get_int(ps, "WritersPerFile");

--- a/petaio.c
+++ b/petaio.c
@@ -320,6 +320,7 @@ static void petaio_write_header(BigFile * bf) {
     (0 != big_block_set_attr(&bh, "BoxSize", &All.BoxSize, "f8", 1)) ||
     (0 != big_block_set_attr(&bh, "OmegaLambda", &All.CP.OmegaLambda, "f8", 1)) ||
     (0 != big_block_set_attr(&bh, "RSDFactor", &RSD, "f8", 1)) ||
+    (0 != big_block_set_attr(&bh, "UsePeculiarVelocity", &All.IO.UsePeculiarVelocity, "i4", 1)) ||
     (0 != big_block_set_attr(&bh, "Omega0", &All.CP.Omega0, "f8", 1)) ||
     (0 != big_block_set_attr(&bh, "CMBTemperature", &All.CP.CMBTemperature, "f8", 1)) ||
     (0 != big_block_set_attr(&bh, "OmegaBaryon", &All.CP.OmegaBaryon, "f8", 1)) ||
@@ -348,6 +349,16 @@ _get_attr_double(BigBlock * bh, char * name, double def)
     }
     return foo;
 }
+static int
+_get_attr_int(BigBlock * bh, char * name, int def)
+{
+    int foo;
+    if(0 != big_block_get_attr(bh, name, &foo, "i4", 1)) {
+        foo = def;
+    }
+    return foo;
+}
+
 static void
 petaio_read_header_internal(BigFile * bf) {
     BigBlock bh = {0};
@@ -375,6 +386,9 @@ petaio_read_header_internal(BigFile * bf) {
     All.UnitVelocity_in_cm_per_s = _get_attr_double(&bh, "UnitVelocity_in_cm_per_s", 1e5); /* 1 km/sec */
     All.UnitLength_in_cm = _get_attr_double(&bh, "UnitLength_in_cm",  3.085678e21); /* 1.0 Kpc /h */
     All.UnitMass_in_g = _get_attr_double(&bh, "UnitMass_in_g", 1.989e43); /* 1e10 Msun/h */
+
+    /* Fall back to use a**2 * dx/dt if UsePeculiarVelocity is not set in IC */
+    All.IO.UsePeculiarVelocity = _get_attr_int(&bh, "UsePeculiarVelocity", 0);
 
     if(0 != big_block_get_attr(&bh, "TotNumPartInit", All.NTotalInit, "u8", 6)) {
         int ptype;


### PR DESCRIPTION
This removes the paramfile flag UsePeculiarVelocity. The behavior is now encoded in the IC file -- if IC file has legacy Gadget velocity, MP-Gadget will do a**2 dx / dt like BlueTides-i. If IC file has peculiar velocity, MP-Gadget will do peculiar velocity as well. 