### PR TITLE
Star part

### DIFF
--- a/Options.mk.BlueTides
+++ b/Options.mk.BlueTides
@@ -27,7 +27,6 @@ OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
 OPT	+=  -DWINDS
 
 

--- a/Options.mk.BlueTides
+++ b/Options.mk.BlueTides
@@ -25,9 +25,8 @@ OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model
-# most of the sfr modes are controled in paramfile (which needs a overhaul too!)
+# Star formation master switch. Also enables the Wind model
 OPT	+=  -DSFR
-OPT	+=  -DWINDS
 
 
 #-------------------------------------- AGN stuff

--- a/Options.mk.example
+++ b/Options.mk.example
@@ -27,7 +27,6 @@ OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
 OPT	+=  -DWINDS
 
 

--- a/Options.mk.example
+++ b/Options.mk.example
@@ -25,10 +25,8 @@ OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model
-# most of the sfr modes are controled in paramfile (which needs a overhaul too!)
+# Star formation master switch. Also enables the Wind model
 OPT	+=  -DSFR
-OPT	+=  -DWINDS
-
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)

--- a/Options.mk.example.coma
+++ b/Options.mk.example.coma
@@ -17,7 +17,6 @@ OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
 OPT	+=  -DWINDS
 
 #-------------------------------------- AGN stuff

--- a/Options.mk.example.coma
+++ b/Options.mk.example.coma
@@ -15,9 +15,8 @@ OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model
-# most of the sfr modes are controled in paramfile (which needs a overhaul too!)
+# Star formation master switch. Also enables the Wind model
 OPT	+=  -DSFR
-OPT	+=  -DWINDS
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)

--- a/Options.mk.example.icc
+++ b/Options.mk.example.icc
@@ -22,10 +22,8 @@ OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model
-# most of the sfr modes are controled in paramfile (which needs a overhaul too!)
+# Star formation master switch. Also enables the Wind model
 OPT	+=  -DSFR
-OPT	+=  -DWINDS
-
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)

--- a/Options.mk.example.icc
+++ b/Options.mk.example.icc
@@ -24,7 +24,6 @@ OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
 OPT	+=  -DWINDS
 
 

--- a/Options.mk.pfe
+++ b/Options.mk.pfe
@@ -19,7 +19,6 @@ OPT += -DOPENMP_USE_SPINLOCK
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
 OPT	+=  -DWINDS
 
 #-------------------------------------- AGN stuff

--- a/Options.mk.pfe
+++ b/Options.mk.pfe
@@ -19,7 +19,6 @@ OPT += -DOPENMP_USE_SPINLOCK
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DWINDS
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)

--- a/Options.mk.travis
+++ b/Options.mk.travis
@@ -19,7 +19,6 @@ OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & 
 #--------------------------------------- SFR/feedback model
 # most of the sfr modes are controled in paramfile (which needs a overhaul too!)
 OPT	+=  -DSFR
-OPT	+=  -DMETALS
 OPT	+=  -DWINDS
 
 
@@ -28,5 +27,4 @@ OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)
 
 #-------------------------------------------- Things for special behaviour
 OPT	+=  -DINCLUDE_RADIATION		# Add radiation density to backround evolution. Only affects the Hubble flow.
-#OPT	+=  -DTRADITIONAL_SPH_FORMULATION
 OPT	+=  -DNO_ISEND_IRECV_IN_DOMAIN     #sparse MPI_Alltoallv do not use ISEND IRECV

--- a/Options.mk.travis
+++ b/Options.mk.travis
@@ -17,10 +17,8 @@ OPT += -DOPENMP_USE_SPINLOCK
 OPT += -DSPH_GRAD_RHO  # calculate grad of rho in SPH, required for Krumholtz & Gnedin H2 SFR
 
 #--------------------------------------- SFR/feedback model
-# most of the sfr modes are controled in paramfile (which needs a overhaul too!)
+# Star formation master switch. Also enables the Wind model
 OPT	+=  -DSFR
-OPT	+=  -DWINDS
-
 
 #-------------------------------------- AGN stuff
 OPT	+=  -DBLACK_HOLES             # enables Black-Holes (master switch)

--- a/allocate.c
+++ b/allocate.c
@@ -16,7 +16,7 @@
  * The memory for the ordered binary tree of the timeline
  * is also allocated.
  */
-void allocate_memory(void)
+void allocate_memory(int alloc_sph)
 {
     size_t bytes;
     TreeWalk_allocate_memory();
@@ -43,7 +43,7 @@ void allocate_memory(void)
 #endif
     message(0, "Allocated %g MByte for particle storage.\n", bytes / (1024.0 * 1024.0));
 
-    if(NTotal[0] > 0) {
+    if(alloc_sph) {
         SphP = (struct sph_particle_data *) mymalloc("SphP", bytes =
                      All.MaxPart * sizeof(struct sph_particle_data));
         message(0, "Allocated %g MByte for storage of SPH data.\n", bytes / (1024.0 * 1024.0));

--- a/allocate.c
+++ b/allocate.c
@@ -48,6 +48,11 @@ void allocate_memory(void)
                      All.MaxPart * sizeof(struct sph_particle_data));
         message(0, "Allocated %g MByte for storage of SPH data.\n", bytes / (1024.0 * 1024.0));
     }
+    if(All.StarformationOn) {
+        StarP = (struct star_particle_data *) mymalloc("StarP", bytes =
+                     All.MaxPartBh * sizeof(struct star_particle_data));
+        message(0, "Allocated %g MByte for storage of Star data.\n", bytes / (1024.0 * 1024.0));
+    }
     if(All.BlackHoleOn) {
         BhP = (struct bh_particle_data *) mymalloc("BhP", bytes =
                      All.MaxPartBh * sizeof(struct bh_particle_data));

--- a/allvars.c
+++ b/allvars.c
@@ -35,6 +35,7 @@ int NumPart;
 int64_t NLocal[6];
 int64_t NTotal[6];
 int N_bh_slots;
+int N_star_slots;
 int N_sph_slots;
 
 /* variables for input/output , usually only used on process 0 */
@@ -78,3 +79,4 @@ struct particle_data *P;	/*!< holds particle data on local processor */
 struct sph_particle_data * SphP;	/*!< holds SPH particle data on local processor */
 struct bh_particle_data * BhP;	/*!< holds BH particle data on local processor */
 
+struct star_particle_data * StarP;	/*!< holds star particle data on local processor */

--- a/allvars.c
+++ b/allvars.c
@@ -30,9 +30,8 @@ int RestartFlag;		/*!< taken from command line used to start code. 0 is normal s
 				   marks a restart from a snapshot file. */
 int RestartSnapNum;
 
-/* Local number of particles; this shall be made into an array */
+/* Local number of particles */
 int NumPart;
-int64_t NLocal[6];
 int64_t NTotal[6];
 int N_bh_slots;
 int N_star_slots;

--- a/allvars.c
+++ b/allvars.c
@@ -32,7 +32,6 @@ int RestartSnapNum;
 
 /* Local number of particles */
 int NumPart;
-int64_t NTotal[6];
 int N_bh_slots;
 int N_star_slots;
 int N_sph_slots;

--- a/allvars.h
+++ b/allvars.h
@@ -168,8 +168,7 @@ extern int NTask;		/*!< number of processors */
 
 extern int NumPart;		/*!< number of particles on the LOCAL processor */
 
-/* Local number of particles; this is accurate after a GC */
-extern int64_t NLocal[6];
+/* Local number of particles; this is accurate after domain */
 extern int64_t NTotal[6];
 
 /* Number of used BHP slots */

--- a/allvars.h
+++ b/allvars.h
@@ -174,6 +174,7 @@ extern int64_t NTotal[6];
 
 /* Number of used BHP slots */
 extern int N_bh_slots;
+extern int N_star_slots;
 extern int N_sph_slots;
 
 /* variables for input/output , usually only used on process 0 */
@@ -516,7 +517,8 @@ extern struct particle_data
         signed char TimeBin; /* Time step bin; -1 for unassigned.*/
     };
 
-    unsigned int PI; /* particle property index; used by BH. points to the BH property in BhP array.*/
+    unsigned int PI; /* particle property index; used by BH, SPH and STAR.
+                        points to the corresponding structure in **P array.*/
     MyIDType ID;
 
     MyFloat Vel[3];   /* particle velocity at its current time */
@@ -525,12 +527,6 @@ extern struct particle_data
     MyFloat GravPM[3];		/* particle acceleration due to long-range PM gravity force */
 
     MyFloat Potential;		/* gravitational potential. This is the total potential after gravtree+gravpm is called. */
-
-    MyFloat StarFormationTime;		/*!< formation time of star particle: needed to tell when wind is active. */
-
-#ifdef METALS
-    MyFloat Metallicity;		/*!< metallicity of gas or star particle */
-#endif				/* closes METALS */
 
     MyFloat Hsml;
 
@@ -578,6 +574,7 @@ struct bh_particle_data {
     MyFloat Entropy;
     MyFloat Pressure;
     MyFloat SurroundingGasVel[3];
+    MyFloat FormationTime;		/*!< formation time of black hole. */
 
     MyFloat accreted_Mass;
     MyFloat accreted_BHMass;
@@ -590,6 +587,13 @@ struct bh_particle_data {
     short int TimeBinLimit;
 } * BhP;
 
+/*Data for each star particle*/
+extern struct star_particle_data
+{
+    struct particle_data_ext base;
+    MyFloat FormationTime;		/*!< formation time of star particle: needed to tell when wind is active. */
+    MyFloat Metallicity;		/*!< metallicity of star particle */
+} * StarP;
 
 /* the following structure holds data that is stored for each SPH particle in addition to the collisionless
  * variables.
@@ -606,6 +610,7 @@ extern struct sph_particle_data
 #define EOMDensity Density
 #endif
 
+    MyFloat Metallicity;		/*!< metallicity of gas particle */
     MyFloat Entropy;		/*!< current value of entropy (actually entropic function) of particle */
     MyFloat MaxSignalVel;           /*!< maximum signal velocity */
     MyFloat       Density;		/*!< current baryonic mass density of particle */
@@ -638,6 +643,7 @@ extern struct sph_particle_data
 
 #define SPHP(i) SphP[P[i].PI]
 #define BHP(i) BhP[P[i].PI]
+#define STARP(i) StarP[P[i].PI]
 
 #define MPI_UINT64 MPI_UNSIGNED_LONG
 #define MPI_INT64 MPI_LONG

--- a/allvars.h
+++ b/allvars.h
@@ -514,7 +514,7 @@ extern struct particle_data
     };
 
     unsigned int PI; /* particle property index; used by BH, SPH and STAR.
-                        points to the corresponding structure in **P array.*/
+                        points to the corresponding structure in (SPH|BH|STAR)P array.*/
     MyIDType ID;
 
     MyFloat Vel[3];   /* particle velocity at its current time */

--- a/allvars.h
+++ b/allvars.h
@@ -592,6 +592,7 @@ extern struct star_particle_data
 {
     struct particle_data_ext base;
     MyFloat FormationTime;		/*!< formation time of star particle */
+    MyFloat BirthDensity;		/*!< Density of gas particle at star formation. */
     MyFloat Metallicity;		/*!< metallicity of star particle */
 } * StarP;
 

--- a/allvars.h
+++ b/allvars.h
@@ -530,11 +530,6 @@ extern struct particle_data
 
     MyFloat Hsml;
 
-#ifdef BLACK_HOLES
-    /* SwallowID is not reset in blackhole.c thus cannot be in a union */
-    MyIDType SwallowID; /* who will swallow this particle, used only in blackhole.c */
-#endif
-
     /* The peano key is a hash of the position used in the domain decomposition.
      * It is slow to generate so we store it here.*/
     peano_t Key; /* only by domain.c and forcetre.c */
@@ -584,6 +579,9 @@ struct bh_particle_data {
     MyFloat MinPotVel[3];
     MyFloat MinPot;
 
+    MyIDType SwallowID; /* Allows marking of a merging particle. Used only in blackhole.c.
+                           Set to -1 in init.c and only reinitialised if a merger takes place.*/
+
     short int TimeBinLimit;
 } * BhP;
 
@@ -626,6 +624,8 @@ extern struct sph_particle_data
                    indirectly ionization state and mean molecular weight. */
 
 #ifdef BLACK_HOLES
+    MyIDType SwallowID; /* Allows marking of a particle being eaten by a black hole. Used only in blackhole.c.
+                           Set to -1 in init.c and only reinitialised if a merger takes place.*/
     MyFloat       Injected_BH_Energy;
 #endif
 

--- a/allvars.h
+++ b/allvars.h
@@ -168,10 +168,7 @@ extern int NTask;		/*!< number of processors */
 
 extern int NumPart;		/*!< number of particles on the LOCAL processor */
 
-/* Local number of particles; this is accurate after domain */
-extern int64_t NTotal[6];
-
-/* Number of used BHP slots */
+/* Number of used slots */
 extern int N_bh_slots;
 extern int N_star_slots;
 extern int N_sph_slots;

--- a/allvars.h
+++ b/allvars.h
@@ -631,8 +631,6 @@ extern struct sph_particle_data
 
 #ifdef SFR
     MyFloat Sfr;
-#endif
-#ifdef WINDS
     MyFloat DelayTime;		/*!< SH03: remaining maximum decoupling time of wind particle */
                             /*!< VS08: remaining waiting for wind particle to be eligible to form winds again */
 #endif

--- a/allvars.h
+++ b/allvars.h
@@ -591,7 +591,7 @@ struct bh_particle_data {
 extern struct star_particle_data
 {
     struct particle_data_ext base;
-    MyFloat FormationTime;		/*!< formation time of star particle: needed to tell when wind is active. */
+    MyFloat FormationTime;		/*!< formation time of star particle */
     MyFloat Metallicity;		/*!< metallicity of star particle */
 } * StarP;
 

--- a/begrun.c
+++ b/begrun.c
@@ -50,7 +50,7 @@ void begrun(int RestartSnapNum)
     set_units();
 
 #ifdef DEBUG
-    write_pid_file();
+    write_pid_file(All.OutputDir);
     enable_core_dumps_and_fpu_exceptions();
 #endif
 

--- a/begrun.c
+++ b/begrun.c
@@ -170,7 +170,7 @@ set_units(void)
 
     All.CP.Hubble = HUBBLE * All.UnitTime_in_s;
     /*Include massless neutrinos only if we do not have massive neutrino particles*/
-    All.CP.MasslessNeutrinosOn = (NTotal[2] == 0);
+    All.CP.MasslessNeutrinosOn = (All.NTotalInit[2] == 0);
     init_cosmology(&All.CP);
 
     meanweight = 4.0 / (1 + 3 * HYDROGEN_MASSFRAC);	/* note: assuming NEUTRAL GAS */

--- a/blackhole.c
+++ b/blackhole.c
@@ -229,8 +229,8 @@ void blackhole(void)
         total_mdoteddington *= 1.0 / ((4 * M_PI * GRAVITY * C * PROTONMASS /
                     (0.1 * C * C * THOMPSON)) * All.UnitTime_in_s);
 
-        fprintf(FdBlackHoles, "%g %td %g %g %g %g %g\n",
-                All.Time, NTotal[5], total_mass_holes, total_mdot, mdot_in_msun_per_year,
+        fprintf(FdBlackHoles, "%g %d %g %g %g %g %g\n",
+                All.Time, N_bh_slots, total_mass_holes, total_mdot, mdot_in_msun_per_year,
                 total_mass_real, total_mdoteddington);
         fflush(FdBlackHoles);
     }

--- a/blackhole.c
+++ b/blackhole.c
@@ -360,7 +360,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             O->BH_TimeBinLimit = P[other].TimeBin;
     }
 
-#ifdef WINDS
+#ifdef SFR
      /* BH does not accrete wind */
     if(P[other].Type == 0 && SPHP(other).DelayTime > 0) return;
 #endif
@@ -539,7 +539,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
     if(P[other].ID == I->ID) return;
 
-#ifdef WINDS
+#ifdef SFR
      /* BH does not accrete wind */
     if(P[other].Type == 0 && SPHP(other).DelayTime > 0) return;
 #endif

--- a/blackhole.c
+++ b/blackhole.c
@@ -411,14 +411,14 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
         {
             if(P[other].Swallowed) {
                 /* Already marked, prefer to be swallowed by a bigger ID */
-                if(P[other].SwallowID < I->ID) {
-                    P[other].SwallowID = I->ID;
+                if(BHP(other).SwallowID < I->ID) {
+                    BHP(other).SwallowID = I->ID;
                 }
             } else {
                 /* Unmarked, the BH with bigger ID swallows */
                 if(P[other].ID < I->ID) {
                     P[other].Swallowed = 1;
-                    P[other].SwallowID = I->ID;
+                    BHP(other).SwallowID = I->ID;
                 }
             }
         }
@@ -459,13 +459,13 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             {
                 if(P[other].Swallowed) {
                     /* Already marked, prefer to be swallowed by a bigger ID */
-                    if(P[other].SwallowID < I->ID) {
-                        P[other].SwallowID = I->ID;
+                    if(SPHP(other).SwallowID < I->ID) {
+                        SPHP(other).SwallowID = I->ID;
                     }
                 } else {
                     /* Unmarked mark it */
                     P[other].Swallowed = 1;
-                    P[other].SwallowID = I->ID;
+                    SPHP(other).SwallowID = I->ID;
                 }
             }
             unlock_particle(other);
@@ -546,7 +546,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
 
     if(P[other].Swallowed && P[other].Type == 5)	/* we have a black hole merger */
     {
-        if(P[other].SwallowID != I->ID) return;
+        if(BHP(other).SwallowID != I->ID) return;
 
         lock_particle(other);
 
@@ -603,7 +603,7 @@ blackhole_feedback_ngbiter(TreeWalkQueryBHFeedback * I,
     /* Swallowing a gas */
     if(P[other].Swallowed && P[other].Type == 0)
     {
-        if(P[other].SwallowID != I->ID) return;
+        if(SPHP(other).SwallowID != I->ID) return;
 
         lock_particle(other);
 
@@ -681,6 +681,7 @@ blackhole_accretion_copy(int place, TreeWalkQueryBHAccretion * I, TreeWalk * tw)
 static int
 blackhole_feedback_haswork(int n, TreeWalk * tw)
 {
+    /*Black hole not being swallowed*/
     return (P[n].Type == 5) && (!P[n].Swallowed);
 }
 

--- a/blackhole.c
+++ b/blackhole.c
@@ -721,7 +721,7 @@ void blackhole_make_one(int index) {
     P[child].PI = atomic_fetch_and_add(&N_bh_slots, 1);
     P[child].Type = 5;	/* make it a black hole particle */
 
-    P[child].StarFormationTime = All.Time;
+    BHP(child).FormationTime = All.Time;
     /*Ensure that mass is conserved*/
     double BHmass = All.SeedBlackHoleMass;
     if(P[index].Mass <= All.SeedBlackHoleMass) {

--- a/blackhole.c
+++ b/blackhole.c
@@ -180,8 +180,6 @@ void blackhole(void)
 
     message(0, "Beginning black-hole accretion\n");
 
-
-
     N_sph_swallowed = N_BH_swallowed = 0;
 
     /* Let's determine which particles may be swalled and calculate total feedback weights */
@@ -196,12 +194,8 @@ void blackhole(void)
     MPI_Reduce(&N_sph_swallowed, &Ntot_gas_swallowed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&N_BH_swallowed, &Ntot_BH_swallowed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 
-    NLocal[0] -= N_sph_swallowed;
-    NLocal[5] -= N_BH_swallowed;
-
     message(0, "Accretion done: %d gas particles swallowed, %d BH particles swallowed\n",
                 Ntot_gas_swallowed, Ntot_BH_swallowed);
-
 
     double total_mass_real, total_mdoteddington;
     double total_mass_holes, total_mdot;
@@ -718,7 +712,6 @@ void blackhole_make_one(int index) {
 
     int child = domain_fork_particle(index);
 
-    NLocal[5] ++;
     P[child].PI = atomic_fetch_and_add(&N_bh_slots, 1);
     P[child].Type = 5;	/* make it a black hole particle */
 

--- a/density.c
+++ b/density.c
@@ -27,7 +27,7 @@ typedef struct
     TreeWalkQueryBase base;
     MyFloat Vel[3];
     MyFloat Hsml;
-#ifdef WINDS
+#ifdef SFR
     MyFloat DelayTime;
 #endif
     int Type;
@@ -241,7 +241,7 @@ density_copy(int place, TreeWalkQueryDensity * I, TreeWalk * tw)
         sph_VelPred(place, I->Vel);
     }
 
-#ifdef WINDS
+#ifdef SFR
     I->DelayTime = SPHP(place).DelayTime;
 #endif
 
@@ -314,7 +314,7 @@ density_ngbiter(
     double r2 = iter->base.r2;
     double * dist = iter->base.dist;
 
-#ifdef WINDS
+#ifdef SFR
     if(HAS(All.WindModel, WINDS_DECOUPLE_SPH)) {
         if(SPHP(other).DelayTime > 0)	/* partner is a wind particle */
             if(!(I->DelayTime > 0))	/* if I'm not wind, then ignore the wind particle */

--- a/domain.c
+++ b/domain.c
@@ -216,7 +216,7 @@ void domain_maintain(void)
     /* Try a domain exchange.
      * If we have no memory for the particles,
      * bail and do a full domain*/
-    if(0 != domain_exchange(domain_layoutfunc)) {
+    if(0 != domain_exchange(domain_layoutfunc, 1)) {
         domain_decompose_full();
         return;
     }
@@ -333,7 +333,7 @@ domain_attempt_decompose(void)
     domain_balance();
 
     walltime_measure("/Domain/Decompose/Balance");
-    if(domain_exchange(domain_layoutfunc))
+    if(domain_exchange(domain_layoutfunc, 0))
         endrun(1929,"Could not exchange particles\n");
 
     return 0;

--- a/exchange.c
+++ b/exchange.c
@@ -542,7 +542,7 @@ static int domain_countToGo(ptrdiff_t nlimit, int (*layoutfunc)(int p), int fail
 
 void domain_count_particles()
 {
-    int i;
+    int i, NLocal[6];
     for(i = 0; i < 6; i++)
         NLocal[i] = 0;
 

--- a/exchange.h
+++ b/exchange.h
@@ -1,6 +1,6 @@
 #ifndef __EXCHANGE_H
 #define __EXCHANGE_H
 
-int domain_exchange(int (*layoutfunc)(int p));
+int domain_exchange(int (*layoutfunc)(int p), int failfast);
 
 #endif

--- a/fof.c
+++ b/fof.c
@@ -525,7 +525,7 @@ static void add_particle_to_group(struct Group * gdst, int i) {
     }
     if(P[index].Type == 0)
     {
-#ifdef WINDS
+#ifdef SFR
         /* make bh in non wind gas on bh wind*/
         if(SPHP(index).DelayTime <= 0)
 #endif

--- a/fofpetaio.c
+++ b/fofpetaio.c
@@ -195,7 +195,7 @@ static void fof_distribute_particles() {
         P[index].targettask = pi[i].targetTask;
     }
 
-    if(domain_exchange(fof_sorted_layout))
+    if(domain_exchange(fof_sorted_layout,0))
         endrun(1930,"Could not exchange particles\n");
     myfree(pi);
     /* sort SPH and Others independently */
@@ -210,7 +210,7 @@ static void fof_distribute_particles() {
 
 }
 static void fof_return_particles() {
-    if(domain_exchange(fof_origin_layout))
+    if(domain_exchange(fof_origin_layout,0))
         endrun(1931,"Could not exchange particles\n");
 }
 

--- a/garbage.c
+++ b/garbage.c
@@ -173,7 +173,7 @@ domain_garbage_collection_slots(int ptype,
         if(P[i].Type == ptype) {
             SLOT(P[i].PI)->ReverseLink = i;
             if(P[i].PI >= *N_slots) {
-                endrun(1, "slot PI consistency failed2, N_slots = %d, N_bh = %d, PI=%d\n", *N_slots, NLocal[5], P[i].PI);
+                endrun(1, "slot PI consistency failed2, N_slots = %d, NLocal = %d, PI=%d\n", *N_slots, NLocal[ptype], P[i].PI);
             }
             if(SLOT(P[i].PI)->ID != P[i].ID) {
                 endrun(1, "slot id consistency failed1\n");

--- a/garbage.c
+++ b/garbage.c
@@ -173,7 +173,7 @@ domain_garbage_collection_slots(int ptype,
         if(P[i].Type == ptype) {
             SLOT(P[i].PI)->ReverseLink = i;
             if(P[i].PI >= *N_slots) {
-                endrun(1, "slot PI consistency failed2, N_slots = %d, NLocal = %d, PI=%d\n", *N_slots, NLocal[ptype], P[i].PI);
+                endrun(1, "slot PI consistency failed2, N_slots = %d, PI=%d\n", *N_slots, P[i].PI);
             }
             if(SLOT(P[i].PI)->ID != P[i].ID) {
                 endrun(1, "slot id consistency failed1\n");

--- a/garbage.c
+++ b/garbage.c
@@ -91,6 +91,7 @@ domain_garbage_collection(void)
      * and snapshot IO, both take far more time than rebuilding the tree. */
     tree_invalid |= domain_all_garbage_collection();
     tree_invalid |= domain_garbage_collection_slots(5, BhP, sizeof(BhP[0]), &N_bh_slots, All.MaxPartBh);
+    tree_invalid |= domain_garbage_collection_slots(4, StarP, sizeof(StarP[0]), &N_star_slots, All.MaxPartBh);
     tree_invalid |= domain_garbage_collection_slots(0, SphP, sizeof(SphP[0]), &N_sph_slots, All.MaxPart);
 
     MPI_Allreduce(MPI_IN_PLACE, &tree_invalid, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
@@ -172,7 +173,7 @@ domain_garbage_collection_slots(int ptype,
         if(P[i].Type == ptype) {
             SLOT(P[i].PI)->ReverseLink = i;
             if(P[i].PI >= *N_slots) {
-                endrun(1, "slot PI consistency failed2, N_bh_slots = %d, N_bh = %d, PI=%d\n", *N_slots, NLocal[5], P[i].PI);
+                endrun(1, "slot PI consistency failed2, N_slots = %d, N_bh = %d, PI=%d\n", *N_slots, NLocal[5], P[i].PI);
             }
             if(SLOT(P[i].PI)->ID != P[i].ID) {
                 endrun(1, "slot id consistency failed1\n");

--- a/hydra.c
+++ b/hydra.c
@@ -219,7 +219,7 @@ hydro_ngbiter(
                   " We haven't implemented tracer particles and this shall not happen\n");
     }
 
-#ifdef WINDS
+#ifdef SFR
 #ifdef NOWINDTIMESTEPPING
     if(HAS(All.WindModel, WINDS_DECOUPLE_SPH)) {
         if(P[other].Type == 0)
@@ -336,7 +336,7 @@ hydro_ngbiter(
                 + p_over_rho2_j * SPHP(other).DhsmlDensityFactor * dwk_j) / r;
 #endif
 
-#ifdef WINDS
+#ifdef SFR
         if(HAS(All.WindModel, WINDS_DECOUPLE_SPH)) {
             if(P[other].Type == 0)
                 if(SPHP(other).DelayTime > 0)	/* No force by wind particles */
@@ -371,7 +371,7 @@ hydro_postprocess(int i, TreeWalk * tw)
         /* Translate energy change rate into entropy change rate */
         SPHP(i).DtEntropy *= GAMMA_MINUS1 / (All.cf.hubble_a2 * pow(SPHP(i).EOMDensity, GAMMA_MINUS1));
 
-#ifdef WINDS
+#ifdef SFR
         /* if we have winds, we decouple particles briefly if delaytime>0 */
         if(HAS(All.WindModel, WINDS_DECOUPLE_SPH)) {
             if(SPHP(i).DelayTime > 0)

--- a/init.c
+++ b/init.c
@@ -108,10 +108,8 @@ void init(int RestartSnapNum)
             SPHP(i).Ne = 1.0;
             SPHP(i).DivVel = 0;
         }
-#ifdef WINDS
-        SPHP(i).DelayTime = 0;
-#endif
 #ifdef SFR
+        SPHP(i).DelayTime = 0;
         SPHP(i).Sfr = 0;
 #endif
 

--- a/main.c
+++ b/main.c
@@ -60,6 +60,7 @@ int main(int argc, char **argv)
         printf("Size of particle structure       %td  [bytes]\n",sizeof(struct particle_data));
         printf("Size of blackhole structure       %td  [bytes]\n",sizeof(struct bh_particle_data));
         printf("Size of sph particle structure   %td  [bytes]\n",sizeof(struct sph_particle_data));
+        printf("Size of star particle structure   %td  [bytes]\n",sizeof(struct star_particle_data));
     }
 
     read_parameter_file(argv[1]);	/* ... read in parameters for this run */

--- a/param.c
+++ b/param.c
@@ -41,7 +41,7 @@ StarformationCriterionAction(ParameterSet * ps, char * name, void * data)
         message(1, "error: At least use SFR_CRITERION_DENSITY\n");
         return 1;
     }
-#if ! defined SPH_GRAD_RHO || ! defined METALS
+#if ! defined SPH_GRAD_RHO
     if(HAS(v, SFR_CRITERION_MOLECULAR_H2)) {
         message(1, "error: enable SPH_GRAD_RHO to use h2 criterion in sfr \n");
         return 1;
@@ -118,7 +118,7 @@ create_gadget_parameter_set()
     param_declare_string(ps, "InitCondFile", REQUIRED, NULL, "Path to the Initial Condition File");
     param_declare_string(ps, "OutputDir",    REQUIRED, NULL, "Prefix to the output files");
     param_declare_string(ps, "TreeCoolFile", OPTIONAL, "", "Path to the Cooling Table");
-    param_declare_string(ps, "MetalCoolFile", OPTIONAL, "", "Path to the Metal Cooling Table. Refer to cooling.c");
+    param_declare_string(ps, "MetalCoolFile", OPTIONAL, "", "Path to the Metal Cooling Table. Empty string disables metal cooling. Refer to cooling.c");
     param_declare_string(ps, "UVFluctuationFile", OPTIONAL, "", "Path to the UVFluctation Table. Refer to cooling.c.");
 
     static ParameterEnum DensityKernelTypeEnum [] = {
@@ -501,13 +501,6 @@ void read_parameter_file(char *fname)
                       "You must set `StarformationOn=0', or recompile the code.\n");
             All.StarformationOn = 0;
         }
-    #endif
-
-    #ifdef METALS
-    #ifndef SFR
-        endrun(1, "Code was compiled with METALS, but not with SFR.\n"
-                  "This is not allowed.\n");
-    #endif
     #endif
 
         DensityKernel kernel;

--- a/petaio.c
+++ b/petaio.c
@@ -668,10 +668,10 @@ SIMPLE_PROPERTY(Entropy, SPHP(i).Entropy, float, 1)
 #endif
 SIMPLE_PROPERTY(ElectronAbundance, SPHP(i).Ne, float, 1)
 #ifdef SFR
-SIMPLE_PROPERTY(StarFormationTime, STARP(i).FormationTime, float, 1)
+SIMPLE_PROPERTY_TYPE(StarFormationTime, 4, STARP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BirthDensity, STARP(i).BirthDensity, float, 1)
-SIMPLE_PROPERTY(StarMetallicity, STARP(i).Metallicity, float, 1)
-SIMPLE_PROPERTY(GasMetallicity, SPHP(i).Metallicity, float, 1)
+SIMPLE_PROPERTY_TYPE(Metallicity, 4, STARP(i).Metallicity, float, 1)
+SIMPLE_PROPERTY_TYPE(Metallicity, 0, SPHP(i).Metallicity, float, 1)
 static void GTStarFormationRate(int i, float * out) {
     /* Convert to Solar/year */
     *out = get_starformation_rate(i) 
@@ -679,7 +679,7 @@ static void GTStarFormationRate(int i, float * out) {
 }
 #endif
 #ifdef BLACK_HOLES
-SIMPLE_PROPERTY(BlackholeFormationTime, BHP(i).FormationTime, float, 1)
+SIMPLE_PROPERTY_TYPE(StarFormationTime, 5, BHP(i).FormationTime, float, 1)
 SIMPLE_PROPERTY(BlackholeMass, BHP(i).Mass, float, 1)
 SIMPLE_PROPERTY(BlackholeAccretionRate, BHP(i).Mdot, float, 1)
 SIMPLE_PROPERTY(BlackholeProgenitors, BHP(i).CountProgs, float, 1)
@@ -757,14 +757,14 @@ static void register_io_blocks() {
 #ifdef SFR
     IO_REG_WRONLY(StarFormationRate, "f4", 1, 0);
     IO_REG(BirthDensity, "f4", 1, 4);
-    IO_REG(StarFormationTime, "f4", 1, 4);
-    IO_REG(GasMetallicity,       "f4", 1, 0);
-    IO_REG(StarMetallicity,       "f4", 1, 4);
+    IO_REG_TYPE(StarFormationTime, "f4", 1, 4);
+    IO_REG_TYPE(Metallicity,       "f4", 1, 0);
+    IO_REG_TYPE(Metallicity,       "f4", 1, 4);
 #endif /* SFR */
 #ifdef BLACK_HOLES
     /* Blackhole */
+    IO_REG_TYPE(StarFormationTime, "f4", 1, 5);
     IO_REG(BlackholeMass,          "f4", 1, 5);
-    IO_REG(BlackholeFormationTime, "f4", 1, 5);
     IO_REG(BlackholeAccretionRate, "f4", 1, 5);
     IO_REG(BlackholeProgenitors,   "i4", 1, 5);
 #endif

--- a/petaio.c
+++ b/petaio.c
@@ -669,6 +669,7 @@ SIMPLE_PROPERTY(Entropy, SPHP(i).Entropy, float, 1)
 SIMPLE_PROPERTY(ElectronAbundance, SPHP(i).Ne, float, 1)
 #ifdef SFR
 SIMPLE_PROPERTY(StarFormationTime, STARP(i).FormationTime, float, 1)
+SIMPLE_PROPERTY(BirthDensity, STARP(i).BirthDensity, float, 1)
 SIMPLE_PROPERTY(StarMetallicity, STARP(i).Metallicity, float, 1)
 SIMPLE_PROPERTY(GasMetallicity, SPHP(i).Metallicity, float, 1)
 static void GTStarFormationRate(int i, float * out) {
@@ -755,6 +756,7 @@ static void register_io_blocks() {
     /* SF */
 #ifdef SFR
     IO_REG_WRONLY(StarFormationRate, "f4", 1, 0);
+    IO_REG(BirthDensity, "f4", 1, 4);
     IO_REG(StarFormationTime, "f4", 1, 4);
     IO_REG(GasMetallicity,       "f4", 1, 0);
     IO_REG(StarMetallicity,       "f4", 1, 4);

--- a/petaio.c
+++ b/petaio.c
@@ -729,13 +729,15 @@ static void register_io_blocks() {
         IO_REG(Velocity, "f4", 3, i);
         IO_REG(Mass,     "f4", 1, i);
         IO_REG(ID,       "u8", 1, i);
-        IO_REG(Generation,       "u1", 1, i);
         if(All.OutputPotential)
             IO_REG_WRONLY(Potential, "f4", 1, i);
         if(All.SnapshotWithFOF)
             IO_REG_WRONLY(GroupID, "u4", 1, i);
     }
 
+    IO_REG(Generation,       "u1", 1, 0);
+    IO_REG(Generation,       "u1", 1, 4);
+    IO_REG(Generation,       "u1", 1, 5);
     /* Bare Bone SPH*/
     IO_REG(SmoothingLength,  "f4", 1, 0);
     IO_REG(Density,          "f4", 1, 0);

--- a/petaio.h
+++ b/petaio.h
@@ -12,6 +12,7 @@ typedef struct IOTableEntry {
     int ptype;
     char dtype[8];
     int items;
+    int required;
     property_getter getter;
     property_setter setter;
 } IOTableEntry;
@@ -25,7 +26,7 @@ void petaio_readout_buffer(BigArray * array, IOTableEntry * ent);
 void petaio_destroy_buffer(BigArray * array);
 
 void petaio_save_block(BigFile * bf, char * blockname, BigArray * array);
-void petaio_read_block(BigFile * bf, char * blockname, BigArray * array);
+int petaio_read_block(BigFile * bf, char * blockname, BigArray * array, int required);
 
 void petaio_save_snapshot(const char * fmt, ...);
 void petaio_save_restart();
@@ -52,17 +53,20 @@ petaio_build_selection(int * selection,
  * IO_REG_WRONLY declares an io block which is written, but is not read on snapshot load.
  * */
 #define IO_REG(name, dtype, items, ptype) \
-    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , (property_setter) ST ## name)
+    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , (property_setter) ST ## name, 1)
 #define IO_REG_TYPE(name, dtype, items, ptype) \
-    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## ptype ## name , (property_setter) ST ## ptype ## name)
+    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## ptype ## name , (property_setter) ST ## ptype ## name, 0)
 #define IO_REG_WRONLY(name, dtype, items, ptype) \
-    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , NULL)
+    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , NULL, 1)
+#define IO_REG_NONFATAL(name, dtype, items, ptype) \
+    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , (property_setter) ST ## name, 0)
 void io_register_io_block(char * name, 
         char * dtype, 
         int items, 
         int ptype, 
         property_getter getter,
-        property_setter setter
+        property_setter setter,
+        int required
         );
 
 

--- a/petaio.h
+++ b/petaio.h
@@ -47,9 +47,14 @@ petaio_build_selection(int * selection,
  * 
  * SIMPLE_GETTER defines a simple getter reading property from global particle
  * arrays.
+ *
+ * IO_REG_TYPE declares an io block which has a type-specific property setter.
+ * IO_REG_WRONLY declares an io block which is written, but is not read on snapshot load.
  * */
 #define IO_REG(name, dtype, items, ptype) \
     io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , (property_setter) ST ## name)
+#define IO_REG_TYPE(name, dtype, items, ptype) \
+    io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## ptype ## name , (property_setter) ST ## ptype ## name)
 #define IO_REG_WRONLY(name, dtype, items, ptype) \
     io_register_io_block(# name, dtype, items, ptype, (property_getter) GT ## name , NULL)
 void io_register_io_block(char * name, 
@@ -90,6 +95,10 @@ static void name(int i, type * out) { \
 #define SIMPLE_PROPERTY(name, field, type, items) \
     SIMPLE_GETTER(GT ## name , field, type, items) \
     SIMPLE_SETTER(ST ## name , field, type, items) \
+/*A property with getters and setters that are type specific*/
+#define SIMPLE_PROPERTY_TYPE(name, ptype, field, type, items) \
+    SIMPLE_GETTER(GT ## ptype ## name , field, type, items) \
+    SIMPLE_SETTER(ST ## ptype ## name , field, type, items) \
 /* 
  * currently 4096 entries are supported 
  * */

--- a/proto.h
+++ b/proto.h
@@ -1,7 +1,6 @@
 #ifndef PROTO_H
 #define PROTO_H
 
-void allocate_memory(void);
 void begrun(int RestartSnapNum);
 void
 open_outputfiles(int RestartsnapNum);

--- a/run.c
+++ b/run.c
@@ -370,7 +370,7 @@ void compute_accelerations(int is_PM, int FirstStep)
     if(FirstStep)
         grav_short_tree();
 
-    if(NTotal[0] > 0)
+    if(All.NTotalInit[0] > 0)
     {
         /***** density *****/
         message(0, "Start density computation...\n");

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -734,6 +734,7 @@ static int make_particle_star(int i) {
     /*Increase counters*/
     sum_mass_stars += P[newstar].Mass;
     STARP(newstar).FormationTime = All.Time;
+    STARP(newstar).BirthDensity = SPHP(i).Density;
     /*Copy metallicity*/
     STARP(newstar).Metallicity = SPHP(i).Metallicity;
 #ifdef WINDS

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -1040,7 +1040,7 @@ static double get_sfr_factor_due_to_h2(int i) {
     return 1.0;
 #else
     double tau_fmol;
-    double zoverzsun = P[i].Metallicity/METAL_YIELD;
+    double zoverzsun = SPHP(i).Metallicity/METAL_YIELD;
     tau_fmol = ev_NH_from_GradRho(SPHP(i).GradRho,P[i].Hsml,SPHP(i).Density,1) * All.cf.a2inv;
     tau_fmol *= (0.1 + zoverzsun);
     if(tau_fmol>0) {

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -703,7 +703,6 @@ static int make_particle_star(int i) {
         /* here we turn the gas particle itself into a star */
         stars_converted++;
         newstar = i;
-        NLocal[0] --;
     }
     else
     {
@@ -720,8 +719,7 @@ static int make_particle_star(int i) {
     STARP(newstar).base.ID = P[newstar].ID;
     /* set ptype */
     P[newstar].Type = 4;
-    NLocal[4] ++;
-    /*Increase counters*/
+    /*Set properties*/
     sum_mass_stars += P[newstar].Mass;
     STARP(newstar).FormationTime = All.Time;
     STARP(newstar).BirthDensity = SPHP(i).Density;

--- a/system.c
+++ b/system.c
@@ -77,7 +77,7 @@ void catch_fatal(int sig)
   raise(sig);
 }
 
-void write_pid_file(void)
+void write_pid_file(char * outdir)
 {
   pid_t my_pid;
   char mode[8], buf[500];
@@ -86,7 +86,7 @@ void write_pid_file(void)
 
   my_pid = getpid();
 
-  sprintf(buf, "%s%s", All.OutputDir, "PIDs.txt");
+  sprintf(buf, "%s%s", outdir, "PIDs.txt");
 
   strcpy(mode, "a+");
 

--- a/system.h
+++ b/system.h
@@ -5,7 +5,7 @@
 void catch_abort(int sig);
 void catch_fatal(int sig);
 void enable_core_dumps_and_fpu_exceptions(void);
-void write_pid_file(void);
+void write_pid_file(char * outdir);
 #endif
 
 int cluster_get_num_hosts();

--- a/timestep.c
+++ b/timestep.c
@@ -772,6 +772,7 @@ void print_timebin_statistics(int NumCurrentTiStep)
     int64_t tot_count[TIMEBINS+1] = {0};
     int64_t tot_count_type[6][TIMEBINS+1] = {0};
     int64_t tot_num_force = 0;
+    int64_t TotNumPart = 0, TotNumType[6] = {0};
 
     for(i = 0; i < 6; i ++) {
         sumup_large_ints(TIMEBINS+1, TimeBinCountType[i], tot_count_type[i]);
@@ -779,8 +780,12 @@ void print_timebin_statistics(int NumCurrentTiStep)
 
     for(i = 0; i<TIMEBINS+1; i++) {
         int j;
-        for(j=0; j<6; j++)
+        for(j=0; j<6; j++) {
             tot_count[i] += tot_count_type[j][i];
+            /*Note j*/
+            TotNumType[j] += tot_count_type[j][i];
+            TotNumPart += tot_count_type[j][i];
+        }
         if(is_timebin_active(i, All.Ti_Current))
             tot_num_force += tot_count[i];
     }
@@ -796,11 +801,8 @@ void print_timebin_statistics(int NumCurrentTiStep)
                 All.TimeStep, log(All.Time) - log(All.Time - All.TimeStep),
                 extra);
 
-    int64_t TotNumPart = 0;
-    for(i = 0; i < 6; i ++) TotNumPart += NTotal[i];
-
     message(0, "TotNumPart: %013ld SPH %013ld BH %010ld STAR %013ld \n",
-                TotNumPart, NTotal[0], NTotal[5], NTotal[4]);
+                TotNumPart, TotNumType[0], TotNumType[5], TotNumType[4]);
     message(0,     "Occupied: % 12ld % 12ld % 12ld % 12ld % 12ld % 12ld dt\n", 0L, 1L, 2L, 3L, 4L, 5L);
 
     for(i = TIMEBINS;  i >= 0; i--) {


### PR DESCRIPTION
This pull request moves star-specific fields out of particle_data into a struct star_particle_data
I move Generation, SwallowID Metallicity and FormationTime. METALS is always on because 
now it has very small cost. I added a BirthDensity field based like the one found in EAGLE to the stars.
The save macros are extended to allow for arrays that are only found in some types. 

WINDS was removed too, because we have the WindModel = nowind parameter anyway.

Because my eyes hurt when implementing this, I also substantially cleaned up the domain exchange. It now has loops. I will probably add a unit test for it in a subsequent pull request.

I thought of making SwallowID be a temporary array, but since we want to save swallowed particles to the snapshot eventually I decided not to.

This has minimal performance impact and minimal effect on output, except that garbage is a little slower (but that needs updating anyway).

Fixes #19