### PR TITLE
Darkenergy

### DIFF
--- a/cosmology.c
+++ b/cosmology.c
@@ -10,6 +10,7 @@
 #define  STEFAN_BOLTZMANN 5.670373e-5
 
 static Cosmology * CP = NULL;
+static inline double OmegaFLD(const double a);
 
 void init_cosmology(Cosmology * CP_in)
 {
@@ -53,7 +54,8 @@ double hubble_function(double a)
 
     /* first do the terms in SQRT */
     hubble_a = CP->OmegaLambda;
-
+    
+    hubble_a += OmegaFLD(a);
     hubble_a += CP->OmegaK / (a * a);
     hubble_a += CP->Omega0 / (a * a * a);
 
@@ -130,6 +132,16 @@ double F_Omega(double a)
     double dD1da=0;
     double D1 = growth(a, &dD1da);
     return a / D1 * dD1da;
+}
+
+/*Dark energy density as a function of time:
+ * OmegaFLD(a)  ~ exp(-3 int((1+w(a))/a da)_a^1
+ * and w(a) = w0 + (1-a) wa*/
+static inline double OmegaFLD(const double a)
+{
+    if(CP->Omega_fld == 0.)
+        return 0;
+    return CP->Omega_fld * pow(a, 3 * (1 + CP->w0_fld + CP->wa_fld))*exp(3*CP->wa_fld*(1-a));
 }
 
 static double sigma2_int(double k, void * p)

--- a/cosmology.h
+++ b/cosmology.h
@@ -11,6 +11,9 @@ typedef struct {
     double OmegaK; /* Curvature density, derived from Omega0 and OmegaLambda */
     double OmegaNu0; /* Massless Neutrino density, derived from T_CMB0, useful only if there are no massive neutrino particles */
     double OmegaLambda;  /* vaccum energy density relative to crictical density (at z=0) */
+    double Omega_fld; /*Energy density of dark energy fluid at z=0*/
+    double w0_fld; /*Dark energy equation of state parameter*/
+    double wa_fld; /*Dark energy equation of state evolution parameter*/
     double OmegaBaryon;  /* baryon density in units of the critical density (at z=0) */
     double HubbleParam;  /* little `h', i.e. Hubble constant in units of 100 km/s/Mpc. */
     double Hubble; /* 100 km/s/Mpc in whatever units we want*/

--- a/genic/params.c
+++ b/genic/params.c
@@ -23,10 +23,10 @@ create_parameters()
     param_declare_string(ps, "OutputDir", REQUIRED, 0, "");
     param_declare_string(ps, "FileBase", REQUIRED, 0, "");
 
-    param_declare_double(ps, "Omega0", REQUIRED, 0, "");
-    param_declare_double(ps, "OmegaLambda", REQUIRED, 0, "");
-    param_declare_double(ps, "OmegaBaryon", REQUIRED, 0, "");
-    param_declare_double(ps, "HubbleParam", REQUIRED, 0.7, "Hubble parameter");
+    param_declare_double(ps, "Omega0", REQUIRED, 0.2814, "");
+    param_declare_double(ps, "OmegaBaryon", REQUIRED, 0.0464, "");
+    param_declare_double(ps, "OmegaLambda", REQUIRED, 0.7186, "Dark energy density at z=0");
+    param_declare_double(ps, "HubbleParam", REQUIRED, 0.697, "Hubble parameter");
     param_declare_int(ps,    "ProduceGas", REQUIRED, 0, "Should we create baryon particles?");
     param_declare_double(ps, "BoxSize", REQUIRED, 0, "");
     param_declare_double(ps, "Redshift", REQUIRED, 99, "Starting redshift");

--- a/genic/params.c
+++ b/genic/params.c
@@ -35,6 +35,9 @@ create_parameters()
     param_declare_int(ps, "Seed", REQUIRED, 0, "");
     param_declare_int(ps, "Unitary", OPTIONAL, 0, "If non-zero, generate unitary gaussians where |g| == 1.0.");
     param_declare_int(ps, "WhichSpectrum", OPTIONAL, 2, "Type of spectrum, 2 for file ");
+    param_declare_double(ps, "Omega_fld", OPTIONAL, 0, "Energy density of dark energy fluid.");
+    param_declare_double(ps, "w0_fld", OPTIONAL, -1., "Dark energy equation of state");
+    param_declare_double(ps, "wa_fld", OPTIONAL, 0, "Dark energy evolution parameter");
 
     param_declare_double(ps, "MaxMemSizePerNode", OPTIONAL, 0.6 * get_physmem_bytes() / (1024 * 1024), "");
     param_declare_double(ps, "CMBTemperature", OPTIONAL, 2.7255, "CMB temperature in K");
@@ -87,6 +90,11 @@ void read_parameterfile(char *fname)
     CP.OmegaLambda = param_get_double(ps, "OmegaLambda");
     CP.OmegaBaryon = param_get_double(ps, "OmegaBaryon");
     CP.HubbleParam = param_get_double(ps, "HubbleParam");
+    CP.Omega_fld = param_get_double(ps, "Omega_fld");
+    CP.w0_fld = param_get_double(ps,"w0_fld");
+    CP.wa_fld = param_get_double(ps,"wa_fld");
+    if(CP.OmegaLambda > 0 && CP.Omega_fld > 0)
+        endrun(0, "Cannot have OmegaLambda and Omega_fld (evolving dark energy) at the same time!\n");
     CP.CMBTemperature = param_get_double(ps, "CMBTemperature");
     CP.RadiationOn = param_get_double(ps, "RadiationOn");
     /* If massive neutrinos are implemented and enabled this

--- a/param.c
+++ b/param.c
@@ -138,7 +138,10 @@ create_gadget_parameter_set()
     param_declare_double(ps, "CMBTemperature", OPTIONAL, 2.7255,
             "Present-day CMB temperature in Kelvin, default from Fixsen 2009; affects background if RadiationOn is set.");
     param_declare_double(ps, "OmegaBaryon", REQUIRED, 0.0464, "");
-    param_declare_double(ps, "OmegaLambda", REQUIRED, 0.7186, "");
+    param_declare_double(ps, "OmegaLambda", REQUIRED, 0.7186, "Dark energy density at z=0");
+    param_declare_double(ps, "Omega_fld", OPTIONAL, 0, "Energy density of dark energy fluid.");
+    param_declare_double(ps, "w0_fld", OPTIONAL, -1., "Dark energy equation of state.");
+    param_declare_double(ps, "wa_fld", OPTIONAL, 0, "Dark energy evolution parameter.");
     param_declare_double(ps, "HubbleParam", REQUIRED, 0.697, "");
 
     param_declare_int(ps,    "OutputPotential", OPTIONAL, 1, "Save the potential in snapshots.");
@@ -354,6 +357,11 @@ void read_parameter_file(char *fname)
         All.CP.Omega0 = param_get_double(ps, "Omega0");
         All.CP.OmegaBaryon = param_get_double(ps, "OmegaBaryon");
         All.CP.OmegaLambda = param_get_double(ps, "OmegaLambda");
+        All.CP.Omega_fld = param_get_double(ps, "Omega_fld");
+        if(All.CP.OmegaLambda > 0 && All.CP.Omega_fld > 0)
+            endrun(0, "Cannot have OmegaLambda and Omega_fld (evolving dark energy) at the same time!\n");
+        All.CP.w0_fld = param_get_double(ps,"w0_fld");
+        All.CP.wa_fld = param_get_double(ps,"wa_fld");
         All.CP.HubbleParam = param_get_double(ps, "HubbleParam");
 
         All.DomainOverDecompositionFactor = param_get_int(ps, "DomainOverDecompositionFactor");


### PR DESCRIPTION
Add parameters for a simple (w0, wa) dark energy parametrisation, so we can run simulations with dark energy models of the type most commonly used by cosmologists.