### PR TITLE
Soften cleanup

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -26,7 +26,7 @@ OBJECTS  =  \
 	 cooling.o openmpsort.o \
 	 system.o allocate.o density.o \
 	 treewalk.o cosmology.o \
-	 gravshort-tree.o gravshort-tree-old.o gravshort-pair.o hydra.o  timefac.o \
+	 gravshort-tree.o gravshort-pair.o hydra.o  timefac.o \
 	 gravpm.o powerspectrum.o \
 	 forcetree.o peano.o \
 	 petapm.o longrange.o \

--- a/allvars.h
+++ b/allvars.h
@@ -372,13 +372,10 @@ extern struct global_data_all_processes
     double DensityContrastLimit; /* limit of density contrast ratio for hydro force calculation */
     double HydroCostFactor; /* cost factor for hydro in load balancing. */
 
-    double GravitySoftening;
-    double GravitySofteningGas;
-                                /* when 0, that we have enabled adaptive gravitational softening for gas particles.
-                                  This means that ForceSoftening[0] is unused. Instead pairwise interactions use 
-                                  max(P[i].Hsml,ForceSoftening[P[j].Type]) for the particle is considered.*/
-
-    double ForceSoftening[6];   /* the same, but multiplied by a factor 2.8 - at that scale the force is Newtonian */
+    double GravitySoftening; /* Softening is as a fraction of DM mean separation. */
+    double GravitySofteningGas;  /* if 0, enable adaptive gravitational softening for gas particles, which uses the Hsml as ForceSoftening */
+    double ForceSoftening[6]; /* 2.8 times the softening length; it is the scale where the force is Newtonian; */
+    double TreeNodeMinSize; /* The minimum size of a Force Tree Node in length units. */
     double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
 
     /* some filenames */

--- a/allvars.h
+++ b/allvars.h
@@ -371,26 +371,16 @@ extern struct global_data_all_processes
                              */
     double DensityContrastLimit; /* limit of density contrast ratio for hydro force calculation */
     double HydroCostFactor; /* cost factor for hydro in load balancing. */
-    double SofteningGas,		/*!< for type 0 */
-           SofteningHalo,		/*!< for type 1 */
-           SofteningDisk,		/*!< for type 2 */
-           SofteningBulge,		/*!< for type 3 */
-           SofteningStars,		/*!< for type 4 */
-           SofteningBndry;		/*!< for type 5 */
 
-    double SofteningGasMaxPhys,	/*!< for type 0 */
-           SofteningHaloMaxPhys,	/*!< for type 1 */
-           SofteningDiskMaxPhys,	/*!< for type 2 */
-           SofteningBulgeMaxPhys,	/*!< for type 3 */
-           SofteningStarsMaxPhys,	/*!< for type 4 */
-           SofteningBndryMaxPhys;	/*!< for type 5 */
-
-    double SofteningTable[6];	/*!< current (comoving) gravitational softening lengths for each particle type */
-    double ForceSoftening[6];	/*!< the same, but multiplied by a factor 2.8 - at that scale the force is Newtonian */
-    double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
-    int AdaptiveGravsoftForGas; /*Flags that we have enabled adaptive gravitational softening for gas particles.
+    double GravitySoftening;
+    double GravitySofteningGas;
+                                /* when 0, that we have enabled adaptive gravitational softening for gas particles.
                                   This means that ForceSoftening[0] is unused. Instead pairwise interactions use 
                                   max(P[i].Hsml,ForceSoftening[P[j].Type]) for the particle is considered.*/
+
+    double SofteningTable[6];   /* current (comoving) gravitational softening lengths for each particle type */
+    double ForceSoftening[6];   /* the same, but multiplied by a factor 2.8 - at that scale the force is Newtonian */
+    double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
 
     /* some filenames */
     char InitCondFile[100],

--- a/allvars.h
+++ b/allvars.h
@@ -372,9 +372,10 @@ extern struct global_data_all_processes
     double DensityContrastLimit; /* limit of density contrast ratio for hydro force calculation */
     double HydroCostFactor; /* cost factor for hydro in load balancing. */
 
-    double GravitySoftening; /* Softening is as a fraction of DM mean separation. */
+    double GravitySoftening; /* Softening as a fraction of DM mean separation. */
     double GravitySofteningGas;  /* if 0, enable adaptive gravitational softening for gas particles, which uses the Hsml as ForceSoftening */
-    double ForceSoftening[6]; /* 2.8 times the softening length; it is the scale where the force is Newtonian; */
+
+    double GravitySofteningTable[6]; /* the softening length; the scale where the force is Newtonian is 2.8 x this; in length units. */
     double TreeNodeMinSize; /* The minimum size of a Force Tree Node in length units. */
     double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
 
@@ -629,12 +630,14 @@ extern struct sph_particle_data
 
 #define MPI_UINT64 MPI_UNSIGNED_LONG
 #define MPI_INT64 MPI_LONG
+
 static inline double FORCE_SOFTENING(int i)
 {
-    if (All.ForceSoftening[0] == 0 && P[i].Type == 0) {
+    if (All.GravitySofteningTable[0] == 0 && P[i].Type == 0) {
         return P[i].Hsml;
     } else {
-        return All.ForceSoftening[P[i].Type];
+        /* Force is newtonian beyond this.*/
+        return 2.8 * All.GravitySofteningTable[P[i].Type];
     }
 }
 #endif

--- a/allvars.h
+++ b/allvars.h
@@ -378,7 +378,6 @@ extern struct global_data_all_processes
                                   This means that ForceSoftening[0] is unused. Instead pairwise interactions use 
                                   max(P[i].Hsml,ForceSoftening[P[j].Type]) for the particle is considered.*/
 
-    double SofteningTable[6];   /* current (comoving) gravitational softening lengths for each particle type */
     double ForceSoftening[6];   /* the same, but multiplied by a factor 2.8 - at that scale the force is Newtonian */
     double MeanSeparation[6]; /* mean separation between particles. 0 if the species doesn't exist. */
 
@@ -633,5 +632,12 @@ extern struct sph_particle_data
 
 #define MPI_UINT64 MPI_UNSIGNED_LONG
 #define MPI_INT64 MPI_LONG
-
+static inline double get_softening(int i)
+{
+    if (All.ForceSoftening[0] == 0 && P[i].Type == 0) {
+        return P[i].Hsml;
+    } else {
+        return All.ForceSoftening[P[i].Type];
+    }
+}
 #endif

--- a/allvars.h
+++ b/allvars.h
@@ -632,7 +632,7 @@ extern struct sph_particle_data
 
 #define MPI_UINT64 MPI_UNSIGNED_LONG
 #define MPI_INT64 MPI_LONG
-static inline double get_softening(int i)
+static inline double FORCE_SOFTENING(int i)
 {
     if (All.ForceSoftening[0] == 0 && P[i].Type == 0) {
         return P[i].Hsml;

--- a/begrun.c
+++ b/begrun.c
@@ -33,6 +33,7 @@
 
 
 static void set_units();
+static void set_softenings();
 
 
 /*! This function performs the initial set-up of the simulation. First, the
@@ -47,6 +48,7 @@ void begrun(int RestartSnapNum)
 
     petaio_read_header(RestartSnapNum);
 
+    set_softenings();
     set_units();
 
 #ifdef DEBUG
@@ -223,3 +225,35 @@ set_units(void)
     }
     message(0, "\n");
 }
+
+/*! This function sets the (comoving) softening length of all particle
+ *  types in the table All.SofteningTable[...].  We check that the physical
+ *  softening length is bounded by the Softening-MaxPhys values.
+ */
+static void
+set_softenings()
+{
+    int i;
+
+    for(i = 0; i < 6; i ++)
+        All.ForceSoftening[i] = 2.8 * All.GravitySoftening * All.MeanSeparation[1];
+
+    /* 0: Gas is collesional */
+    All.ForceSoftening[0] = 2.8 * All.GravitySofteningGas * All.MeanSeparation[1];
+
+    All.MinGasHsml = All.MinGasHsmlFractional * All.ForceSoftening[1];
+
+    for(i = 0; i < 6; i ++) {
+        message(0, "GravitySoftening[%d] = %g\n", i, All.ForceSoftening[i] / 2.8);
+    }
+
+    double minsoft = 0;
+    for(i = 0; i<6; i++) {
+        if(All.ForceSoftening[i] <= 0) continue;
+        if(minsoft == 0 || minsoft > All.ForceSoftening[i])
+            minsoft = All.ForceSoftening[i];
+    }
+    /* FIXME: make this a parameter. */
+    All.TreeNodeMinSize = 1.0e-3 * minsoft;
+}
+

--- a/begrun.c
+++ b/begrun.c
@@ -236,24 +236,24 @@ set_softenings()
     int i;
 
     for(i = 0; i < 6; i ++)
-        All.ForceSoftening[i] = 2.8 * All.GravitySoftening * All.MeanSeparation[1];
+        All.GravitySofteningTable[i] = All.GravitySoftening * All.MeanSeparation[1];
 
     /* 0: Gas is collesional */
-    All.ForceSoftening[0] = 2.8 * All.GravitySofteningGas * All.MeanSeparation[1];
+    All.GravitySofteningTable[0] = All.GravitySofteningGas * All.MeanSeparation[1];
 
-    All.MinGasHsml = All.MinGasHsmlFractional * All.ForceSoftening[1];
+    All.MinGasHsml = All.MinGasHsmlFractional * All.GravitySofteningTable[1];
 
     for(i = 0; i < 6; i ++) {
-        message(0, "GravitySoftening[%d] = %g\n", i, All.ForceSoftening[i] / 2.8);
+        message(0, "GravitySoftening[%d] = %g\n", i, All.GravitySofteningTable[i]);
     }
 
     double minsoft = 0;
     for(i = 0; i<6; i++) {
-        if(All.ForceSoftening[i] <= 0) continue;
-        if(minsoft == 0 || minsoft > All.ForceSoftening[i])
-            minsoft = All.ForceSoftening[i];
+        if(All.GravitySofteningTable[i] <= 0) continue;
+        if(minsoft == 0 || minsoft > All.GravitySofteningTable[i])
+            minsoft = All.GravitySofteningTable[i];
     }
     /* FIXME: make this a parameter. */
-    All.TreeNodeMinSize = 1.0e-3 * minsoft;
+    All.TreeNodeMinSize = 1.0e-3 * 2.8 * minsoft;
 }
 

--- a/examples/travis/paramfile.gadget
+++ b/examples/travis/paramfile.gadget
@@ -60,19 +60,8 @@ BufferSize = 100          # in MByte
 
 MinGasHsmlFractional 0.01
 
-SofteningGas = 50
-SofteningHalo = 50
-SofteningDisk = 0
-SofteningBulge = 0
-SofteningStars = 50
-SofteningBndry = 50             #This is BH
-
-SofteningGasMaxPhys = 50
-SofteningHaloMaxPhys = 50
-SofteningDiskMaxPhys = 0
-SofteningBulgeMaxPhys = 0
-SofteningStarsMaxPhys = 50
-SofteningBndryMaxPhys = 50      #This is BH
+GravitySoftening = 0.03333
+GravitySofteningGas = 0.00 # enable adaptive softening of gas
 
 #----------------------BH Stuff-------------------------
 BlackHoleOn = 0

--- a/forcetree.c
+++ b/forcetree.c
@@ -315,11 +315,7 @@ int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
     int nnext = tb.firstnode;		/* index of first free node */
 
     /*Minimum size of the node depends on the minimum of all force softenings*/
-    double minsoft = 0;
-    for(i = 0; i<6; i++)
-        if((minsoft == 0 || minsoft > All.ForceSoftening[i]) && All.ForceSoftening[i] > 0)
-            minsoft = All.ForceSoftening[i];
-    const double minlen = 1.0e-3 * minsoft;
+    const double minlen = All.TreeNodeMinSize;
     /*Count of how many times we hit this limit*/
     int closepairs = 0;
 

--- a/forcetree.c
+++ b/forcetree.c
@@ -637,7 +637,7 @@ force_set_node_softening(struct NODE * pnode, const int new_type, const double h
         if(All.ForceSoftening[new_type] > All.ForceSoftening[pnode->f.MaxSofteningType])
             pnode->f.MaxSofteningType = new_type;
         if((All.ForceSoftening[new_type] != All.ForceSoftening[pnode->f.MaxSofteningType])
-                || (All.AdaptiveGravsoftForGas && new_type == 0))
+                || (All.ForceSoftening[0] == 0 && new_type == 0))
             pnode->f.MixedSofteningsInNode = 1;
     }
 }

--- a/forcetree.c
+++ b/forcetree.c
@@ -626,37 +626,40 @@ force_get_prev_node(int no, const struct TreeBuilder tb)
     }
 }
 
-/*Sets the node softening on a node.*/
+/* Sets the node softening on a node.
+ *
+ * */
 static void
-force_set_node_softening(struct NODE * pnode, const int new_type, const double hsml)
+force_set_node_softening(struct NODE * pnode, double MaxSoftening)
 {
-    if(pnode->f.MaxSofteningType == 7)
-        pnode->f.MaxSofteningType = new_type;
-    else
-    {
-        if(All.ForceSoftening[new_type] > All.ForceSoftening[pnode->f.MaxSofteningType])
-            pnode->f.MaxSofteningType = new_type;
-        if((All.ForceSoftening[new_type] != All.ForceSoftening[pnode->f.MaxSofteningType])
-                || (All.ForceSoftening[0] == 0 && new_type == 0))
+
+    if(pnode->u.d.MaxSoftening > 0) {
+        /* already set? mark MixedSoftenings */
+        if(MaxSoftening != pnode->u.d.MaxSoftening) {
             pnode->f.MixedSofteningsInNode = 1;
+        }
+    }
+
+    if(MaxSoftening > pnode->u.d.MaxSoftening) {
+        pnode->u.d.MaxSoftening = MaxSoftening;
     }
 }
 
 static void
-add_particle_moment_to_node(struct NODE * pnode, const struct particle_data * pa)
+add_particle_moment_to_node(struct NODE * pnode, int i)
 {
     int k;
-    pnode->u.d.mass += (pa->Mass);
+    pnode->u.d.mass += (P[i].Mass);
     for(k=0; k<3; k++)
-        pnode->u.d.s[k] += (pa->Mass * pa->Pos[k]);
+        pnode->u.d.s[k] += (P[i].Mass * P[i].Pos[k]);
 
-    if(pa->Type == 0)
+    if(P[i].Type == 0)
     {
-        if(pa->Hsml > pnode->u.d.hmax)
-            pnode->u.d.hmax = pa->Hsml;
+        if(P[i].Hsml > pnode->u.d.hmax)
+            pnode->u.d.hmax = P[i].Hsml;
     }
 
-    force_set_node_softening(pnode, pa->Type, pa->Hsml);
+    force_set_node_softening(pnode, get_softening(i));
 }
 
 /*! this routine determines the multipole moments for a given internal node
@@ -698,7 +701,6 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
         return no;
     }
 
-    Nodes[no].f.MaxSofteningType=7;
     int j, suns[8];
     /* this "backup" is necessary because the nextnode
      * entry will overwrite one element (union!) */
@@ -706,10 +708,12 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
         suns[j] = Nodes[no].u.suns[j];
 
     memset(&Nodes[no].u.d.s,0,3*sizeof(MyFloat));
-    Nodes[no].u.d.mass=0;
-    Nodes[no].u.d.hmax=0;
-    Nodes[no].f.DependsOnLocalMass=0;
-    Nodes[no].f.MixedSofteningsInNode=0;
+
+    Nodes[no].u.d.mass = 0;
+    Nodes[no].u.d.hmax = 0;
+    Nodes[no].u.d.MaxSoftening = -1;
+    Nodes[no].f.DependsOnLocalMass = 0;
+    Nodes[no].f.MixedSofteningsInNode = 0;
 
     for(j = 0; j < 8; j++)
     {
@@ -746,14 +750,14 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
             if(Nodes[p].u.d.hmax > Nodes[no].u.d.hmax)
                 Nodes[no].u.d.hmax = Nodes[p].u.d.hmax;
 
-            force_set_node_softening(&Nodes[no], Nodes[p].f.MaxSofteningType, Nodes[p].u.d.hmax);
+            force_set_node_softening(&Nodes[no], Nodes[p].u.d.MaxSoftening);
         }
         else /* a list of particles */
         {
             /* add all particles in this tree-node */
             int next = p;
             while(next != -1) {
-                add_particle_moment_to_node(&Nodes[no], &P[next]);
+                add_particle_moment_to_node(&Nodes[no], next);
                 next = force_get_next_node(next, tb);
             }
         }
@@ -796,9 +800,9 @@ void force_exchange_pseudodata(void)
         MyFloat mass;
         MyFloat hmax;
         struct {
-            unsigned int MaxSofteningType :3; /* bits 2-4 */
             unsigned int MixedSofteningsInNode :1;
         };
+        MyFloat MaxSoftening;
     }
     *TopLeafMoments;
 
@@ -817,7 +821,7 @@ void force_exchange_pseudodata(void)
         TopLeafMoments[i].s[2] = Nodes[no].u.d.s[2];
         TopLeafMoments[i].mass = Nodes[no].u.d.mass;
         TopLeafMoments[i].hmax = Nodes[no].u.d.hmax;
-        TopLeafMoments[i].MaxSofteningType = Nodes[no].f.MaxSofteningType;
+        TopLeafMoments[i].MaxSoftening = Nodes[no].u.d.MaxSoftening;
         TopLeafMoments[i].MixedSofteningsInNode = Nodes[no].f.MixedSofteningsInNode;
 
         /*Set the local base nodes dependence on local mass*/
@@ -862,7 +866,7 @@ void force_exchange_pseudodata(void)
             Nodes[no].u.d.s[2] = TopLeafMoments[i].s[2];
             Nodes[no].u.d.mass = TopLeafMoments[i].mass;
             Nodes[no].u.d.hmax = TopLeafMoments[i].hmax;
-            Nodes[no].f.MaxSofteningType = TopLeafMoments[i].MaxSofteningType;
+            Nodes[no].u.d.MaxSoftening = TopLeafMoments[i].MaxSoftening;
             Nodes[no].f.MixedSofteningsInNode = TopLeafMoments[i].MixedSofteningsInNode;
          }
     }
@@ -879,14 +883,13 @@ void force_treeupdate_pseudos(int no, const struct TreeBuilder tb)
     MyFloat hmax;
     MyFloat s[3], mass;
 
-    int maxsofttype;
+    MyFloat MaxSoftening = -1;
 
     mass = 0;
     s[0] = 0;
     s[1] = 0;
     s[2] = 0;
     hmax = 0;
-    maxsofttype = 7;
 
     p = Nodes[no].u.d.nextnode;
 
@@ -910,17 +913,22 @@ void force_treeupdate_pseudos(int no, const struct TreeBuilder tb)
 
         Nodes[no].f.MixedSofteningsInNode = Nodes[p].f.MixedSofteningsInNode;
 
-        if(maxsofttype == 7)
-            maxsofttype = Nodes[p].f.MaxSofteningType;
+        if(MaxSoftening < 0)
+            MaxSoftening = Nodes[p].u.d.MaxSoftening;
         else
         {
-            int current_maxsofttype = Nodes[p].f.MaxSofteningType;
-            if(current_maxsofttype != 7)
+            MyFloat current_maxsoft = Nodes[p].u.d.MaxSoftening;
+
+            if(current_maxsoft >= 0)
             {
-                if(All.ForceSoftening[current_maxsofttype] > All.ForceSoftening[maxsofttype])
-                    maxsofttype = current_maxsofttype;
-                if(All.ForceSoftening[current_maxsofttype] != All.ForceSoftening[maxsofttype])
+                if(current_maxsoft > MaxSoftening) {
+                    MaxSoftening = current_maxsoft;
+                }
+
+                if(current_maxsoft != MaxSoftening) {
+                    /* The node has in-homogenous softening */
                     Nodes[no].f.MixedSofteningsInNode = 1;
+                }
             }
         }
         p = Nodes[p].u.d.sibling;
@@ -946,7 +954,7 @@ void force_treeupdate_pseudos(int no, const struct TreeBuilder tb)
 
     Nodes[no].u.d.hmax = hmax;
 
-    Nodes[no].f.MaxSofteningType = maxsofttype;
+    Nodes[no].u.d.MaxSoftening = MaxSoftening;
 }
 
 /*! This function updates the hmax-values in tree nodes that hold SPH

--- a/forcetree.c
+++ b/forcetree.c
@@ -659,7 +659,7 @@ add_particle_moment_to_node(struct NODE * pnode, int i)
             pnode->u.d.hmax = P[i].Hsml;
     }
 
-    force_set_node_softening(pnode, get_softening(i));
+    force_set_node_softening(pnode, FORCE_SOFTENING(i));
 }
 
 /*! this routine determines the multipole moments for a given internal node

--- a/forcetree.c
+++ b/forcetree.c
@@ -630,7 +630,7 @@ force_get_prev_node(int no, const struct TreeBuilder tb)
  *
  * */
 static void
-force_set_node_softening(struct NODE * pnode, double MaxSoftening)
+force_adjust_node_softening(struct NODE * pnode, double MaxSoftening)
 {
 
     if(pnode->u.d.MaxSoftening > 0) {
@@ -659,7 +659,7 @@ add_particle_moment_to_node(struct NODE * pnode, int i)
             pnode->u.d.hmax = P[i].Hsml;
     }
 
-    force_set_node_softening(pnode, FORCE_SOFTENING(i));
+    force_adjust_node_softening(pnode, FORCE_SOFTENING(i));
 }
 
 /*! this routine determines the multipole moments for a given internal node
@@ -750,7 +750,7 @@ force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder 
             if(Nodes[p].u.d.hmax > Nodes[no].u.d.hmax)
                 Nodes[no].u.d.hmax = Nodes[p].u.d.hmax;
 
-            force_set_node_softening(&Nodes[no], Nodes[p].u.d.MaxSoftening);
+            force_adjust_node_softening(&Nodes[no], Nodes[p].u.d.MaxSoftening);
         }
         else /* a list of particles */
         {

--- a/forcetree.h
+++ b/forcetree.h
@@ -18,11 +18,7 @@ extern struct NODE
         unsigned int InternalTopLevel :1; /* TopLevel and has a child which is also TopLevel*/
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
-        /* Stores the largest softening in the node. The short-range
-         * gravitational force solver will check this and use it
-         * open the node if a particle is closer.*/
-        unsigned int MaxSofteningType :3;
-        unsigned int MixedSofteningsInNode :1;
+        unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
     } f;
     union
     {
@@ -34,6 +30,9 @@ extern struct NODE
             int sibling;		/*!< this gives the next node in the walk in case the current node can be used */
             int nextnode;		/*!< this gives the next node in case the current node needs to be opened */
             MyFloat hmax;			/*!< maximum SPH smoothing length in node. Only used for gas particles */
+            MyFloat MaxSoftening;  /* Stores the largest softening in the node. The short-range
+                                 * gravitational force solver will check this and use it
+                                 * open the node if a particle is closer.*/
         }
         d;
     }

--- a/gravshort-pair.c
+++ b/gravshort-pair.c
@@ -75,7 +75,7 @@ grav_short_pair_ngbiter(
     double mass = P[other].Mass;
 
     double h = I->Soft;
-    double otherh = get_softening(other);
+    double otherh = FORCE_SOFTENING(other);
     if (otherh > h) h = otherh;
 
     double fac, pot;

--- a/gravshort-pair.c
+++ b/gravshort-pair.c
@@ -74,10 +74,9 @@ grav_short_pair_ngbiter(
 
     double mass = P[other].Mass;
 
-    double h = All.ForceSoftening[I->Type];
-
-    if(h < All.ForceSoftening[P[other].Type])
-        h = All.ForceSoftening[P[other].Type];
+    double h = I->Soft;
+    double otherh = get_softening(other);
+    if (otherh > h) h = otherh;
 
     double fac, pot;
 

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -158,7 +158,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
 
                 h = All.ForceSoftening[ptype];
                 otherh = All.ForceSoftening[P[no].Type];
-                if(All.AdaptiveGravsoftForGas) {
+                if(All.ForceSoftening[0] == 0) {
                     if(ptype == 0)
                         h = input->Soft;
                     if(P[no].Type == 0 && h < P[no].Hsml)
@@ -250,7 +250,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
 
                 h = All.ForceSoftening[ptype];
                 otherh = All.ForceSoftening[nop->f.MaxSofteningType];
-                if(All.AdaptiveGravsoftForGas) {
+                if(All.ForceSoftening[0] == 0) {
                     if(ptype == 0)
                         h = input->Soft;
                     if(otherh < nop->u.d.hmax)

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -242,11 +242,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 }
 
                 h = input->Soft;
-                otherh = All.ForceSoftening[nop->f.MaxSofteningType];
-                if(All.ForceSoftening[0] == 0) {
-                    if(otherh < nop->u.d.hmax)
-                        otherh = nop->u.d.hmax;
-                }
+                otherh = nop->u.d.MaxSoftening;
                 if(h < otherh)
                 {
                     h = otherh;

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -129,7 +129,6 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
     const double pos_x = input->base.Pos[0];
     const double pos_y = input->base.Pos[1];
     const double pos_z = input->base.Pos[2];
-    const int ptype = input->Type;
 
     /*Start the tree walk*/
     int no = input->base.NodeList[0];
@@ -156,14 +155,8 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
 
                 mass = P[no].Mass;
 
-                h = All.ForceSoftening[ptype];
-                otherh = All.ForceSoftening[P[no].Type];
-                if(All.ForceSoftening[0] == 0) {
-                    if(ptype == 0)
-                        h = input->Soft;
-                    if(P[no].Type == 0 && h < P[no].Hsml)
-                        otherh = P[no].Hsml;
-                }
+                h = input->Soft;
+                otherh = get_softening(no);
                 if(h < otherh)
                     h = otherh;
                 no = Nextnode[no];
@@ -248,11 +241,9 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                     }
                 }
 
-                h = All.ForceSoftening[ptype];
+                h = input->Soft;
                 otherh = All.ForceSoftening[nop->f.MaxSofteningType];
                 if(All.ForceSoftening[0] == 0) {
-                    if(ptype == 0)
-                        h = input->Soft;
                     if(otherh < nop->u.d.hmax)
                         otherh = nop->u.d.hmax;
                 }

--- a/gravshort-tree.c
+++ b/gravshort-tree.c
@@ -156,7 +156,7 @@ int force_treeev_shortrange(TreeWalkQueryGravShort * input,
                 mass = P[no].Mass;
 
                 h = input->Soft;
-                otherh = get_softening(no);
+                otherh = FORCE_SOFTENING(no);
                 if(h < otherh)
                     h = otherh;
                 no = Nextnode[no];

--- a/gravshort.h
+++ b/gravshort.h
@@ -49,7 +49,7 @@ grav_short_copy(int place, TreeWalkQueryGravShort * input, TreeWalk * tw)
 {
     input->Type = P[place].Type;
 
-    if(All.AdaptiveGravsoftForGas && P[place].Type == 0)
+    if(All.ForceSoftening[0] == 0 && P[place].Type == 0)
         input->Soft = P[place].Hsml;
     /*Compute old acceleration before we over-write things*/
     double aold=0;

--- a/gravshort.h
+++ b/gravshort.h
@@ -36,7 +36,7 @@ grav_short_postprocess(int i, TreeWalk * tw)
     P[i].GravAccel[2] *= All.G;
     /* calculate the potential */
     /* remove self-potential */
-    P[i].Potential += P[i].Mass / (get_softening(i) / 2.8);
+    P[i].Potential += P[i].Mass / (FORCE_SOFTENING(i) / 2.8);
 
     P[i].Potential -= 2.8372975 * pow(P[i].Mass, 2.0 / 3) *
         pow(All.CP.Omega0 * 3 * All.CP.Hubble * All.CP.Hubble / (8 * M_PI * All.G), 1.0 / 3);
@@ -48,7 +48,7 @@ static void
 grav_short_copy(int place, TreeWalkQueryGravShort * input, TreeWalk * tw)
 {
     input->Type = P[place].Type;
-    input->Soft = get_softening(place);
+    input->Soft = FORCE_SOFTENING(place);
     /*Compute old acceleration before we over-write things*/
     double aold=0;
     int i;

--- a/gravshort.h
+++ b/gravshort.h
@@ -36,7 +36,7 @@ grav_short_postprocess(int i, TreeWalk * tw)
     P[i].GravAccel[2] *= All.G;
     /* calculate the potential */
     /* remove self-potential */
-    P[i].Potential += P[i].Mass / All.SofteningTable[P[i].Type];
+    P[i].Potential += P[i].Mass / (get_softening(i) / 2.8);
 
     P[i].Potential -= 2.8372975 * pow(P[i].Mass, 2.0 / 3) *
         pow(All.CP.Omega0 * 3 * All.CP.Hubble * All.CP.Hubble / (8 * M_PI * All.G), 1.0 / 3);
@@ -48,9 +48,7 @@ static void
 grav_short_copy(int place, TreeWalkQueryGravShort * input, TreeWalk * tw)
 {
     input->Type = P[place].Type;
-
-    if(All.ForceSoftening[0] == 0 && P[place].Type == 0)
-        input->Soft = P[place].Hsml;
+    input->Soft = get_softening(place);
     /*Compute old acceleration before we over-write things*/
     double aold=0;
     int i;

--- a/init.c
+++ b/init.c
@@ -209,15 +209,16 @@ setup_smoothinglengths(int RestartSnapNum)
             P[i].Hsml =
                 pow(3.0 / (4 * M_PI) * All.DesNumNgb * P[i].Mass / (massfactor * Nodes[no].u.d.mass),
                         1.0 / 3) * Nodes[no].len;
-            if(All.SofteningTable[0] != 0 && P[i].Hsml > 500.0 * All.SofteningTable[0])
-                P[i].Hsml = All.SofteningTable[0];
+
+            if(All.ForceSoftening[0] != 0 && P[i].Hsml > 500.0 * All.ForceSoftening[0])
+                P[i].Hsml = All.ForceSoftening[0];
         }
     }
 
 #ifdef BLACK_HOLES
     for(i = 0; i < NumPart; i++)
         if(P[i].Type == 5) {
-            P[i].Hsml = All.SofteningTable[5];
+            P[i].Hsml = All.ForceSoftening[5];
             BHP(i).TimeBinLimit = -1;
         }
 #endif

--- a/init.c
+++ b/init.c
@@ -210,15 +210,20 @@ setup_smoothinglengths(int RestartSnapNum)
                 pow(3.0 / (4 * M_PI) * All.DesNumNgb * P[i].Mass / (massfactor * Nodes[no].u.d.mass),
                         1.0 / 3) * Nodes[no].len;
 
-            if(All.ForceSoftening[0] != 0 && P[i].Hsml > 500.0 * All.ForceSoftening[0])
-                P[i].Hsml = All.ForceSoftening[0];
+            /* recover from a poor initial guess */
+            if(P[i].Hsml > 500.0 * All.MeanSeparation[0])
+                P[i].Hsml = All.MeanSeparation[0];
         }
     }
 
 #ifdef BLACK_HOLES
+    /* FIXME: move this inside the condition above and
+      * save BHs in the snapshots to avoid this; */
     for(i = 0; i < NumPart; i++)
         if(P[i].Type == 5) {
-            P[i].Hsml = All.ForceSoftening[5];
+            /* Anything non-zero would work, but since BH tends to be in high density region, 
+             *  use a small number */
+            P[i].Hsml = 0.01 * All.MeanSeparation[0];
             BHP(i).TimeBinLimit = -1;
         }
 #endif

--- a/param.c
+++ b/param.c
@@ -196,7 +196,7 @@ create_gadget_parameter_set()
     param_declare_int(ps, "FastParticleType", OPTIONAL, 2, "Particles of this type will not decrease the timestep. Default neutrinos.");
 
     param_declare_double(ps, "GravitySoftening", OPTIONAL, 1./30., "Softening for collisionless particles; units of mean separation of DM. ForceSoftening is 2.8 times this.");
-    param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 1./30., "Softening for collisionless particles; units of mean separation of DM; 0 to use Hsml of last step. ");
+    param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 1./30., "Softening for collisional particles (Gas); units of mean separation of DM; 0 to use Hsml of last step. ");
 
     param_declare_double(ps, "BufferSize", OPTIONAL, 100, "");
     param_declare_double(ps, "PartAllocFactor", REQUIRED, 0, "");

--- a/param.c
+++ b/param.c
@@ -195,8 +195,8 @@ create_gadget_parameter_set()
     param_declare_int(ps, "RadiationOn", OPTIONAL, 0, "Include radiation density in the background evolution.");
     param_declare_int(ps, "FastParticleType", OPTIONAL, 2, "Particles of this type will not decrease the timestep. Default neutrinos.");
 
-    param_declare_double(ps, "GravitySoftening", OPTIONAL, 0.05, "Gravitational softening for collisionless particles; units of mean separation of DM.");
-    param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 0.05, "Gravitational softening for collisionless particles; units of mean separation of DM; 0 for adaptive ");
+    param_declare_double(ps, "GravitySoftening", OPTIONAL, 1./30., "Softening for collisionless particles; units of mean separation of DM. ForceSoftening is 2.8 times this.");
+    param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 1./30., "Softening for collisionless particles; units of mean separation of DM; 0 to use Hsml of last step. ");
 
     param_declare_double(ps, "BufferSize", OPTIONAL, 100, "");
     param_declare_double(ps, "PartAllocFactor", REQUIRED, 0, "");

--- a/param.c
+++ b/param.c
@@ -159,7 +159,7 @@ create_gadget_parameter_set()
     param_declare_double(ps, "Asmth", OPTIONAL, 1.25, "The scale of the short-range/long-range force split in units of FFT-mesh cells. Gadget-2 paper says larger values may be more accurate.");
     param_declare_int(ps,    "Nmesh", REQUIRED, 0, "");
 
-    param_declare_double(ps, "MinGasHsmlFractional", OPTIONAL, 0, "");
+    param_declare_double(ps, "MinGasHsmlFractional", OPTIONAL, 0, "Minimal gas Hsml as a fraction of gravity softening.");
     param_declare_double(ps, "MaxGasVel", OPTIONAL, 3e5, "");
 
     param_declare_int(ps,    "TypeOfTimestepCriterion", OPTIONAL, 0, "Compatibility only. Has no effect");
@@ -195,19 +195,8 @@ create_gadget_parameter_set()
     param_declare_int(ps, "RadiationOn", OPTIONAL, 0, "Include radiation density in the background evolution.");
     param_declare_int(ps, "FastParticleType", OPTIONAL, 2, "Particles of this type will not decrease the timestep. Default neutrinos.");
 
-    param_declare_int(ps, "AdaptiveGravsoftForGas", OPTIONAL, 0, "Gravitational softening for gas particles is the smoothing length.");
-    param_declare_double(ps, "SofteningHalo", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningDisk", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningBulge", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningGas", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningStars", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningBndry", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningHaloMaxPhys", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningDiskMaxPhys", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningBulgeMaxPhys", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningGasMaxPhys", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningStarsMaxPhys", REQUIRED, 0, "");
-    param_declare_double(ps, "SofteningBndryMaxPhys", REQUIRED, 0, "");
+    param_declare_double(ps, "GravitySoftening", OPTIONAL, 0.05, "Gravitational softening for collisionless particles; units of mean separation of DM.");
+    param_declare_double(ps, "GravitySofteningGas", OPTIONAL, 0.05, "Gravitational softening for collisionless particles; units of mean separation of DM; 0 for adaptive ");
 
     param_declare_double(ps, "BufferSize", OPTIONAL, 100, "");
     param_declare_double(ps, "PartAllocFactor", REQUIRED, 0, "");
@@ -410,19 +399,8 @@ void read_parameter_file(char *fname)
         All.StarformationOn = param_get_int(ps, "StarformationOn");
         All.TimeLimitCPU = param_get_double(ps, "TimeLimitCPU");
         All.AutoSnapshotTime = param_get_double(ps, "AutoSnapshotTime");
-        All.AdaptiveGravsoftForGas = param_get_int(ps, "AdaptiveGravsoftForGas");
-        All.SofteningHalo = param_get_double(ps, "SofteningHalo");
-        All.SofteningDisk = param_get_double(ps, "SofteningDisk");
-        All.SofteningBulge = param_get_double(ps, "SofteningBulge");
-        All.SofteningGas = param_get_double(ps, "SofteningGas");
-        All.SofteningStars = param_get_double(ps, "SofteningStars");
-        All.SofteningBndry = param_get_double(ps, "SofteningBndry");
-        All.SofteningHaloMaxPhys= param_get_double(ps, "SofteningHaloMaxPhys");
-        All.SofteningDiskMaxPhys= param_get_double(ps, "SofteningDiskMaxPhys");
-        All.SofteningBulgeMaxPhys= param_get_double(ps, "SofteningBulgeMaxPhys");
-        All.SofteningGasMaxPhys= param_get_double(ps, "SofteningGasMaxPhys");
-        All.SofteningStarsMaxPhys= param_get_double(ps, "SofteningStarsMaxPhys");
-        All.SofteningBndryMaxPhys= param_get_double(ps, "SofteningBndryMaxPhys");
+        All.GravitySoftening = param_get_double(ps, "GravitySoftening");
+        All.GravitySofteningGas = param_get_double(ps, "GravitySofteningGas");
 
         All.BufferSize = param_get_double(ps, "BufferSize");
         All.PartAllocFactor = param_get_double(ps, "PartAllocFactor");

--- a/runtests.c
+++ b/runtests.c
@@ -15,7 +15,6 @@
 #include "petaio.h"
 #include "domain.h"
 
-void grav_short_tree_old(void);
 void grav_short_pair(void);
 
 char * GDB_format_particle(int i);
@@ -54,10 +53,4 @@ void runtests()
 
     petaio_save_snapshot("%s/PART-tree-%03d-mpi", All.OutputDir, NTask);
 
-    grav_short_tree_old();
-    grav_short_tree_old();
-    grav_short_tree_old();
-    grav_short_tree_old();
-    message(0, "GravTree old %s\n", GDB_format_particle(0));
-    petaio_save_snapshot("%s/PART-oldtree-%03d-mpi", All.OutputDir, NTask);
 }

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -136,11 +136,11 @@ static int check_moments(const struct TreeBuilder tb, const int numpart, const i
 /*                 printf("node %d ances %d sib %d next %d father %d sfather %d\n",node, ances, sib, force_get_next_node(node, tb), father, sfather); */
             }
             if(!(Nodes[node].u.d.mass < 0.5 && Nodes[node].u.d.mass > -0.5)) {
-                printf("node %d (%d) mass %g / %g TL %d DLM %d MST %d MSN %d ITL %d\n", 
+                printf("node %d (%d) mass %g / %g TL %d DLM %d MS %g MSN %d ITL %d\n", 
                     node, node - tb.firstnode, Nodes[node].u.d.mass, oldmass[node - tb.firstnode],
                     Nodes[node].f.TopLevel,
                     Nodes[node].f.DependsOnLocalMass,
-                    Nodes[node].f.MaxSofteningType,
+                    Nodes[node].u.d.MaxSoftening,
                     Nodes[node].f.MixedSofteningsInNode,
                     Nodes[node].f.InternalTopLevel
                     );

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -379,7 +379,7 @@ static int setup_tree(void **state) {
     All.BoxSize = 8;
     int i;
     for(i=0; i<6; i++)
-        All.ForceSoftening[i] = 0.1;
+        All.GravitySofteningTable[i] = 0.1 / 2.8;
     /*Set up the top-level domain grid*/
     /* The whole tree goes into one topnode.
      * Set up just enough of the TopNode structure that

--- a/timestep.c
+++ b/timestep.c
@@ -409,10 +409,8 @@ get_timestep_dloga(const int p)
     if(ac == 0)
         ac = 1.0e-30;
 
-    double soft = FORCE_SOFTENING(p);
-
     /* mind the factor 2.8 difference between gravity and softening used here. */
-    dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * (soft / 2.8) / ac);
+    dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * (FORCE_SOFTENING(p) / 2.8) / ac);
 
     if(P[p].Type == 0)
     {

--- a/timestep.c
+++ b/timestep.c
@@ -91,40 +91,16 @@ set_softenings(const double time)
 {
     int i;
 
-    if(All.SofteningGas * time > All.SofteningGasMaxPhys)
-        All.SofteningTable[0] = All.SofteningGasMaxPhys / time;
-    else
-        All.SofteningTable[0] = All.SofteningGas;
+    double meansep_dm = All.BoxSize / pow(All.NTotalInit[1], 0.3333333);
+    for(i = 0; i < 6; i ++)
+        All.SofteningTable[i] = All.GravitySoftening * meansep_dm;
 
-    if(All.SofteningHalo * time > All.SofteningHaloMaxPhys)
-        All.SofteningTable[1] = All.SofteningHaloMaxPhys / time;
-    else
-        All.SofteningTable[1] = All.SofteningHalo;
-
-    if(All.SofteningDisk * time > All.SofteningDiskMaxPhys)
-        All.SofteningTable[2] = All.SofteningDiskMaxPhys / time;
-    else
-        All.SofteningTable[2] = All.SofteningDisk;
-
-    if(All.SofteningBulge * time > All.SofteningBulgeMaxPhys)
-        All.SofteningTable[3] = All.SofteningBulgeMaxPhys / time;
-    else
-        All.SofteningTable[3] = All.SofteningBulge;
-
-    if(All.SofteningStars * time > All.SofteningStarsMaxPhys)
-        All.SofteningTable[4] = All.SofteningStarsMaxPhys / time;
-    else
-        All.SofteningTable[4] = All.SofteningStars;
-
-    if(All.SofteningBndry * time > All.SofteningBndryMaxPhys)
-        All.SofteningTable[5] = All.SofteningBndryMaxPhys / time;
-    else
-        All.SofteningTable[5] = All.SofteningBndry;
+    All.SofteningTable[0] = All.GravitySofteningGas * meansep_dm;
 
     for(i = 0; i < 6; i++)
         All.ForceSoftening[i] = 2.8 * All.SofteningTable[i];
 
-    All.MinGasHsml = All.MinGasHsmlFractional * All.ForceSoftening[0];
+    All.MinGasHsml = All.MinGasHsmlFractional * All.ForceSoftening[1];
 }
 
 void
@@ -458,7 +434,7 @@ get_timestep_dloga(const int p)
     double soft = All.SofteningTable[P[p].Type];
     /*Note that Hsml is compared to ForceSoftening,
      * so when comparing to SofteningTable you divide by 2.8*/
-    if(All.AdaptiveGravsoftForGas && P[p].Type == 0)
+    if(All.ForceSoftening[0] == 0 && P[p].Type == 0)
         soft = P[p].Hsml / 2.8;
     dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * soft / ac);
 

--- a/timestep.c
+++ b/timestep.c
@@ -82,23 +82,6 @@ is_PM_timestep(inttime_t ti)
     return ti == PM.start + PM.length;
 }
 
-/*! This function sets the (comoving) softening length of all particle
- *  types in the table All.SofteningTable[...].  We check that the physical
- *  softening length is bounded by the Softening-MaxPhys values.
- */
-void
-set_softenings(const double time)
-{
-    int i;
-
-    for(i = 0; i < 6; i ++)
-        All.ForceSoftening[i] = 2.8 * All.GravitySoftening * All.MeanSeparation[1];
-
-    All.ForceSoftening[0] = 2.8 * All.GravitySofteningGas * All.MeanSeparation[1];
-
-    All.MinGasHsml = All.MinGasHsmlFractional * All.ForceSoftening[1];
-}
-
 void
 set_global_time(double newtime) {
     /*1.0 check for rate setting in sfr_eff.c*/
@@ -117,7 +100,6 @@ set_global_time(double newtime) {
     lightcone_set_time(All.cf.a);
 #endif
     IonizeParams();
-    set_softenings(newtime);
 }
 
 /* This function assigns new timesteps to particles and PM */

--- a/timestep.c
+++ b/timestep.c
@@ -91,14 +91,10 @@ set_softenings(const double time)
 {
     int i;
 
-    double meansep_dm = All.BoxSize / pow(All.NTotalInit[1], 0.3333333);
     for(i = 0; i < 6; i ++)
-        All.SofteningTable[i] = All.GravitySoftening * meansep_dm;
+        All.ForceSoftening[i] = 2.8 * All.GravitySoftening * All.MeanSeparation[1];
 
-    All.SofteningTable[0] = All.GravitySofteningGas * meansep_dm;
-
-    for(i = 0; i < 6; i++)
-        All.ForceSoftening[i] = 2.8 * All.SofteningTable[i];
+    All.ForceSoftening[0] = 2.8 * All.GravitySofteningGas * All.MeanSeparation[1];
 
     All.MinGasHsml = All.MinGasHsmlFractional * All.ForceSoftening[1];
 }
@@ -431,12 +427,10 @@ get_timestep_dloga(const int p)
     if(ac == 0)
         ac = 1.0e-30;
 
-    double soft = All.SofteningTable[P[p].Type];
-    /*Note that Hsml is compared to ForceSoftening,
-     * so when comparing to SofteningTable you divide by 2.8*/
-    if(All.ForceSoftening[0] == 0 && P[p].Type == 0)
-        soft = P[p].Hsml / 2.8;
-    dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * soft / ac);
+    double soft = get_softening(p);
+
+    /* mind the factor 2.8 difference between gravity and softening used here. */
+    dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * (soft / 2.8) / ac);
 
     if(P[p].Type == 0)
     {

--- a/timestep.c
+++ b/timestep.c
@@ -427,7 +427,7 @@ get_timestep_dloga(const int p)
     if(ac == 0)
         ac = 1.0e-30;
 
-    double soft = get_softening(p);
+    double soft = FORCE_SOFTENING(p);
 
     /* mind the factor 2.8 difference between gravity and softening used here. */
     dt = sqrt(2 * All.ErrTolIntAccuracy * All.cf.a * (soft / 2.8) / ac);


### PR DESCRIPTION
This largely removes the twisted Gadget logic in the handling of softening length by

1. decouple type from the softening, allowing a more natural flow of adaptive softening of gas
2. reparametrize the softening to use two parameters; eliminating the non-sense Phys softening limiter -- we argued using adaptive softening made more sense.
3. Use a single array for softenings, not two off only by a factor of 2.8.

Also fixed a potential divide by zero bug of potential calculation when adaptive softening is enabled.

