### PR TITLE
Make BLACK_HOLE parameters exist even if compile flag is off.

### DIFF
--- a/allvars.h
+++ b/allvars.h
@@ -53,16 +53,6 @@
 
 #define MAXHSML 30000.0
 
-#ifdef ONEDIM
-#define DIMS 1
-#else
-#ifdef TWODIMS    /* will only be compiled in 2D case */
-#define DIMS 2
-#else
-#define DIMS 3
-#endif
-#endif
-
 #ifndef  GAMMA
 #define  GAMMA         (5.0/3.0)	/*!< adiabatic index of simulated gas */
 #endif

--- a/densitykernel.h
+++ b/densitykernel.h
@@ -2,7 +2,7 @@
 #define  NUMDIMS 3		/*!< For 3D-normalized kernel */
 #define  NORM_COEFF      4.188790204786	/*!< Coefficient for kernel normalization. Note:  4.0/3 * PI = 4.188790204786 */
 #else
-#ifndef  ONEDIM
+#ifdef  TWODIMS
 #define  NUMDIMS 2		/*!< For 2D-normalized kernel */
 #define  NORM_COEFF      M_PI	/*!< Coefficient for kernel normalization. */
 #else

--- a/examples/dm-only/paramfile.gadget
+++ b/examples/dm-only/paramfile.gadget
@@ -23,6 +23,7 @@ CoolingOn = 0
 StarformationOn = 0
 StarformationCriterion = density
 RadiationOn = 0
+BlackHoleOn = 0
 HydroOn = 0
 WindOn = 0
 

--- a/examples/lya/paramfile.gadget
+++ b/examples/lya/paramfile.gadget
@@ -27,6 +27,7 @@ CoolingOn = 1
 StarformationOn = 1
 RadiationOn = 1
 HydroOn = 1
+BlackHoleOn = 0
 WindOn = 0
 StarformationCriterion = density
 

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -220,9 +220,6 @@ sfr_cool_postprocess(int i, TreeWalk * tw)
         if(flag == 1 || All.QuickLymanAlphaProbability > 0) {
             cooling_direct(i);
         }
-#ifdef ENDLESSSTARS
-        flag = 0;
-#endif
         if(flag == 0) {
             /* active star formation */
             starformation(i);


### PR DESCRIPTION
Make the code accept the same parameters irrespective of the SFR and
BLACK_HOLES compile flags. If these compile flags are not enabled the
(optional) black hole and star parameters just do nothing.

    Fixes: #147