### PR TITLE
hide BH options when not compiled with BH flag

### DIFF
--- a/param.c
+++ b/param.c
@@ -224,6 +224,7 @@ create_gadget_parameter_set()
 
     param_declare_double(ps, "BlackHoleFeedbackRadiusMaxPhys", OPTIONAL, 0, "");
 
+#ifdef BLACK_HOLES
     static ParameterEnum BlackHoleFeedbackMethodEnum [] = {
         {"mass", BH_FEEDBACK_MASS},
         {"volume", BH_FEEDBACK_VOLUME},
@@ -233,6 +234,7 @@ create_gadget_parameter_set()
     };
     param_declare_enum(ps, "BlackHoleFeedbackMethod", BlackHoleFeedbackMethodEnum,
             OPTIONAL, "spline, mass", "");
+#endif
     /*End black holes*/
 
     /*Star formation parameters*/


### PR DESCRIPTION
This PR is related to PR #148 and issue #147 .

It hides BH options when MP-Gadget was compiled without the BH flag. 

I've tested that the code compiles both when the flag is ON and OFF.