### PR TITLE
Allocate more memory for stars with quick lyman alpha star formation

### DIFF
--- a/petaio.c
+++ b/petaio.c
@@ -479,6 +479,9 @@ petaio_read_header_internal(BigFile * bf) {
     All.MaxPart = (int) (All.PartAllocFactor * All.TotNumPartInit / NTask);	
     /* at most 10% of particles can form BH*/
     All.MaxPartBh = (int) (0.1 * All.MaxPart);
+    /*Lyman alpha forms more stars*/
+    if(All.QuickLymanAlphaProbability > 0.5)
+        All.MaxPartBh = All.MaxPart;
 }
 
 void petaio_alloc_buffer(BigArray * array, IOTableEntry * ent, int64_t localsize) {


### PR DESCRIPTION
So we don't run out of memory. This is a short-term hack. The longer term is to allocate star and BH memory with mymalloc2 and increase it dynamically.