### PR TITLE
Move 'time is forward' check into run.c

### DIFF
--- a/examples/lya/paramfile.genic
+++ b/examples/lya/paramfile.genic
@@ -1,9 +1,9 @@
 OutputDir = output # Directory for output
 FileBase = IC              # Base-filename of output files
 
-Ngrid = 64 # Size of cubic grid on which to create particles.
+Ngrid = 128 # Size of cubic grid on which to create particles.
 
-BoxSize = 32000   # Periodic box size of simulation
+BoxSize = 10000   # Periodic box size of simulation
 
 
 

--- a/init.c
+++ b/init.c
@@ -39,9 +39,6 @@ void init(int RestartSnapNum)
 {
     int i, j;
 
-    /* Important to set the global time before reading in the snapshot time as it affects the GT funcs for IO. */
-    set_global_time(All.TimeInit);
-
     /*Add TimeInit and TimeMax to the output list*/
     if (RestartSnapNum < 0) {
         /* allow a first snapshot at IC time; */
@@ -50,12 +47,16 @@ void init(int RestartSnapNum)
         /* skip dumping the exactly same snapshot */
         setup_sync_points(All.TimeInit);
     }
-    /*Read the snapshot*/
-    petaio_read_snapshot(RestartSnapNum);
+
+    init_timebins(log(All.TimeInit));
+
+    /* Important to set the global time before reading in the snapshot time as it affects the GT funcs for IO. */
+    set_global_time(exp(loga_from_ti(All.Ti_Current)));
 
     init_drift_table(All.TimeInit, All.TimeMax);
 
-    init_timebins(log(All.TimeInit));
+    /*Read the snapshot*/
+    petaio_read_snapshot(RestartSnapNum);
 
     /* this ensures the initial BhP array is consistent */
     domain_garbage_collection();

--- a/run.c
+++ b/run.c
@@ -71,6 +71,9 @@ void run(void)
 
         /*Convert back to floating point time*/
         set_global_time(exp(loga_from_ti(All.Ti_Current)));
+        /*1.0 check for rate setting in sfr_eff.c*/
+        if(NumCurrentTiStep > 0 && All.TimeStep < 0)
+            endrun(1, "Negative timestep: %g New Time: %g!\n", All.TimeStep, All.Time);
 
         int is_PM = is_PM_timestep(All.Ti_Current);
 

--- a/timestep.c
+++ b/timestep.c
@@ -84,9 +84,6 @@ is_PM_timestep(inttime_t ti)
 
 void
 set_global_time(double newtime) {
-    /*1.0 check for rate setting in sfr_eff.c*/
-    if(All.Time < 0.99 && newtime < All.Time)
-        endrun(1, "Time error: New timestep (%g) < old (%g)!\n", newtime, All.Time);
     All.TimeStep = newtime - All.Time;
     All.Time = newtime;
     All.cf.a = All.Time;


### PR DESCRIPTION
The check that time is moving forward was prone to floating point and
other problems during simulation startup. Move this into run.c and only
use it after the first timestep completes.

Fixes #149