### PR TITLE
Memory sort

### DIFF
--- a/fof.c
+++ b/fof.c
@@ -14,6 +14,7 @@
 #include "drift.h"
 #include "domain.h"
 #include "mpsort.h"
+#include "openmpsort.h"
 #include "mymalloc.h"
 #include "forcetree.h"
 #include "endrun.h"
@@ -158,7 +159,7 @@ void fof_fof()
     message(0, "attaching gas and star particles to nearest dm particles took = %g sec\n", timediff(t0, t1));
 
     /* sort HaloLabel according to MinID, because we need that for compiling catalogues */
-    qsort(HaloLabel, NumPart, sizeof(struct fof_particle_list), fof_compare_HaloLabel_MinID);
+    qsort_openmp(HaloLabel, NumPart, sizeof(struct fof_particle_list), fof_compare_HaloLabel_MinID);
 
     t0 = second();
 
@@ -781,7 +782,7 @@ static void fof_reduce_groups(
     MPI_Type_commit(&dtype);
 
     /* local groups will be moved to the beginning, we skip them with offset */
-    qsort(groups, nmemb, elsize, fof_compare_Group_MinIDTask);
+    qsort_openmp(groups, nmemb, elsize, fof_compare_Group_MinIDTask);
     /* count how many we have of each task */
     memset(Send_count, 0, sizeof(int) * NTask);
 
@@ -813,8 +814,8 @@ static void fof_reduce_groups(
     }
         
     /* sort the groups according to MinID */
-    qsort(groups, Nmine, elsize, fof_compare_Group_MinID);
-    qsort(images, nimport, elsize, fof_compare_Group_MinID);
+    qsort_openmp(groups, Nmine, elsize, fof_compare_Group_MinID);
+    qsort_openmp(images, nimport, elsize, fof_compare_Group_MinID);
 
     /* merge the imported ones with the local ones */
     start = 0;
@@ -860,7 +861,7 @@ static void fof_reduce_groups(
     }
 
     /* reset the ordering of imported list, such that it can be properly returned */
-    qsort(images, nimport, elsize, fof_compare_Group_OriginalIndex);
+    qsort_openmp(images, nimport, elsize, fof_compare_Group_OriginalIndex);
 
     for(i = 0; i < nimport; i++) {
         struct BaseGroup * gi = (struct BaseGroup*) ((char*) images + i * elsize);
@@ -1188,7 +1189,7 @@ void fof_seed(void)
             j++;
         }
     }
-    qsort(ExportGroups, Nexport, sizeof(ExportGroups[0]), cmp_seed_task);
+    qsort_openmp(ExportGroups, Nexport, sizeof(ExportGroups[0]), cmp_seed_task);
 
     for(i = 0; i < Nexport; i++) {
         Send_count[ExportGroups[i].seed_task]++;

--- a/fofpetaio.c
+++ b/fofpetaio.c
@@ -13,6 +13,7 @@
 #include "exchange.h"
 #include "fof.h"
 #include "mymalloc.h"
+#include "openmpsort.h"
 #include "endrun.h"
 
 static void fof_write_header(BigFile * bf);
@@ -89,7 +90,7 @@ void fof_save_particles(int num) {
 
         /*Sort each type individually*/
         for(i = 0; i < 6; i++)
-            qsort(selection + ptype_offset[i], ptype_count[i], sizeof(int), fof_cmp_selection_by_grnr);
+            qsort_openmp(selection + ptype_offset[i], ptype_count[i], sizeof(int), fof_cmp_selection_by_grnr);
 
         walltime_measure("/FOF/IO/argind");
 

--- a/genic/main.c
+++ b/genic/main.c
@@ -27,8 +27,8 @@ int main(int argc, char **argv)
   /* fixme: make this a mpi bcast */
   read_parameterfile(argv[1]);
 
-  walltime_init(&CT);
   mymalloc_init(MaxMemSizePerNode);
+  walltime_init(&CT);
   const double meanspacing = Box / Ngrid;
   const double shift_gas = -0.5 * (CP.Omega0 - CP.OmegaBaryon) / CP.Omega0 * meanspacing;
   const double shift_dm = +0.5 * CP.OmegaBaryon / CP.Omega0 * meanspacing;

--- a/openmpsort.c
+++ b/openmpsort.c
@@ -5,7 +5,251 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
+#include <stdint.h>
 #include "mymalloc.h"
+/* Below is a merge-sort routine copied directly from glibc version 2.26
+ * (although the code is the same since Dec. 2010, glibc 2.13).
+ * The copy is so that we can control our memory allocation
+ * to use mymalloc instead of the system malloc.
+ * It also means that on machines where libc is not glibc we will
+ * use glibc's routine, which is almost certainly better.*/
+
+/*============================================*/
+/* An alternative to qsort, with an identical interface.
+   This file is part of the GNU C Library.
+   Copyright (C) 1992-2017 Free Software Foundation, Inc.
+   Written by Mike Haertel, September 1988.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+struct msort_param
+{
+  size_t s;
+  size_t var;
+  __compar_fn_t cmp;
+  void *arg;
+  char *t;
+};
+static void msort_with_tmp (const struct msort_param *p, void *b, size_t n);
+
+static void
+msort_with_tmp (const struct msort_param *p, void *b, size_t n)
+{
+  char *b1, *b2;
+  size_t n1, n2;
+
+  if (n <= 1)
+    return;
+
+  n1 = n / 2;
+  n2 = n - n1;
+  b1 = b;
+  b2 = (char *) b + (n1 * p->s);
+
+  msort_with_tmp (p, b1, n1);
+  msort_with_tmp (p, b2, n2);
+
+  char *tmp = p->t;
+  const size_t s = p->s;
+  __compar_fn_t cmp = p->cmp;
+  switch (p->var)
+    {
+    case 0:
+      while (n1 > 0 && n2 > 0)
+        {
+          if ((*cmp) (b1, b2) <= 0)
+            {
+              *(uint32_t *) tmp = *(uint32_t *) b1;
+              b1 += sizeof (uint32_t);
+              --n1;
+            }
+          else
+            {
+              *(uint32_t *) tmp = *(uint32_t *) b2;
+              b2 += sizeof (uint32_t);
+              --n2;
+            }
+          tmp += sizeof (uint32_t);
+        }
+      break;
+    case 1:
+      while (n1 > 0 && n2 > 0)
+        {
+          if ((*cmp) (b1, b2) <= 0)
+            {
+              *(uint64_t *) tmp = *(uint64_t *) b1;
+              b1 += sizeof (uint64_t);
+              --n1;
+            }
+          else
+            {
+              *(uint64_t *) tmp = *(uint64_t *) b2;
+              b2 += sizeof (uint64_t);
+              --n2;
+            }
+          tmp += sizeof (uint64_t);
+        }
+      break;
+    case 2:
+      while (n1 > 0 && n2 > 0)
+        {
+          unsigned long *tmpl = (unsigned long *) tmp;
+          unsigned long *bl;
+
+          tmp += s;
+          if ((*cmp) (b1, b2) <= 0)
+            {
+              bl = (unsigned long *) b1;
+              b1 += s;
+              --n1;
+            }
+          else
+            {
+              bl = (unsigned long *) b2;
+              b2 += s;
+              --n2;
+            }
+          while (tmpl < (unsigned long *) tmp)
+            *tmpl++ = *bl++;
+        }
+      break;
+    case 3:
+      while (n1 > 0 && n2 > 0)
+        {
+          if ((*cmp) (*(const void **) b1, *(const void **) b2) <= 0)
+            {
+              *(void **) tmp = *(void **) b1;
+              b1 += sizeof (void *);
+              --n1;
+            }
+          else
+            {
+              *(void **) tmp = *(void **) b2;
+              b2 += sizeof (void *);
+              --n2;
+            }
+          tmp += sizeof (void *);
+        }
+      break;
+    default:
+      while (n1 > 0 && n2 > 0)
+        {
+          if ((*cmp) (b1, b2) <= 0)
+            {
+              tmp = (char *) memcpy (tmp, b1, s) + s;
+              b1 += s;
+              --n1;
+            }
+          else
+            {
+              tmp = (char *) memcpy (tmp, b2, s) + s;
+              b2 += s;
+              --n2;
+            }
+        }
+      break;
+    }
+
+  if (n1 > 0)
+    memcpy (tmp, b1, n1 * s);
+  memcpy (b, p->t, (n - n2) * s);
+}
+
+
+void
+__qsort (void *b, size_t n, size_t s, __compar_fn_t cmp, char * tmp)
+{
+  /*TODO: Parallelize this algorithm and thus make it use indirect sorting*/
+/*   size_t size = n * s; */
+
+  /* For large object sizes use indirect sorting.  */
+/*   if (s > 32) */
+/*     size = 2 * n * sizeof (void *) + s; */
+
+  /* In the original glibc version, the code switches to quicksort here
+   * if low on memory. Since we already have allocated a copy of the array
+   * for the openmp parallel bit above, this is unnecessary*/
+  struct msort_param p;
+  p.t = tmp;
+  p.s = s;
+  p.var = 4;
+  p.cmp = cmp;
+
+  if (s > 32)
+    {
+      /* Indirect sorting.  */
+      char *ip = (char *) b;
+      void **tp = (void **) (p.t + n * sizeof (void *));
+      void **t = tp;
+      void *tmp_storage = (void *) (tp + n);
+
+      while ((void *) t < tmp_storage)
+        {
+          *t++ = ip;
+          ip += s;
+        }
+      p.s = sizeof (void *);
+      p.var = 3;
+      msort_with_tmp (&p, p.t + n * sizeof (void *), n);
+
+      /* tp[0] .. tp[n - 1] is now sorted, copy around entries of
+         the original array.  Knuth vol. 3 (2nd ed.) exercise 5.2-10.  */
+      char *kp;
+      size_t i;
+      for (i = 0, ip = (char *) b; i < n; i++, ip += s)
+        if ((kp = tp[i]) != ip)
+          {
+            size_t j = i;
+            char *jp = ip;
+            memcpy (tmp_storage, ip, s);
+
+            do
+              {
+                size_t k = (kp - (char *) b) / s;
+                tp[j] = jp;
+                memcpy (jp, kp, s);
+                j = k;
+                jp = kp;
+                kp = tp[k];
+              }
+            while (kp != ip);
+
+            tp[j] = jp;
+            memcpy (jp, tmp_storage, s);
+          }
+    }
+  else
+    {
+      if ((s & (sizeof (uint32_t) - 1)) == 0
+          && ((char *) b - (char *) 0) % __alignof__ (uint32_t) == 0)
+        {
+          if (s == sizeof (uint32_t))
+            p.var = 0;
+          else if (s == sizeof (uint64_t)
+                   && ((char *) b - (char *) 0) % __alignof__ (uint64_t) == 0)
+            p.var = 1;
+          else if ((s & (sizeof (unsigned long) - 1)) == 0
+                   && ((char *) b - (char *) 0)
+                      % __alignof__ (unsigned long) == 0)
+            p.var = 2;
+        }
+      msort_with_tmp (&p, b, n);
+    }
+}
+/*End code copied from glibc*/
+/*=====================================================*/
 
 static void merge(void * base1, size_t nmemb1, void * base2, size_t nmemb2, void * output, size_t size,
          int(*compar)(const void *, const void *)) {
@@ -43,6 +287,9 @@ void qsort_openmp(void *base, size_t nmemb, size_t size,
     void ** Atmp = Atmp_store;
 
     void * tmp;
+    /*NOTE: if this allocation becomes a problem,
+     * switch to glibc's quicksort (serial!) or use
+     * an indirect sort*/
     tmp = mymalloc("qsort", size * nmemb);
 
 #pragma omp parallel
@@ -60,8 +307,7 @@ void qsort_openmp(void *base, size_t nmemb, size_t size,
         Abase[tid] = ((char*) base) + start * size;
         Atmp[tid] = ((char*) tmp) + start * size;
 
-        qsort( Abase[tid], Anmemb[tid], size, compar);
-
+        __qsort( Abase[tid], Anmemb[tid], size, compar, Atmp[tid]);
         /* now each sub array is sorted, kick start the merging */
 
         int sep;

--- a/tests/test_openmpsort.c
+++ b/tests/test_openmpsort.c
@@ -24,6 +24,46 @@ static int compare(const void *a, const void *b) {
         return ( *(int*)a - *(int*)b );
 }
 
+struct __data
+{
+    int dd[200];
+};
+/*This exists because large structs are sorted indirectly*/
+static void test_openmpsort_struct(void ** state) {
+    int i;
+    // set up array to be sorted
+    //a bad case is 87763 threads = 12
+    int size = 187763;
+    struct __data *a = (struct __data *) malloc(size * sizeof(struct __data));
+
+    srand48(8675309);
+    for(i = 0; i < size; i++)
+        a[i].dd[0] = (int) (size * drand48());
+
+    double start, end;
+
+    start = omp_get_wtime();
+    qsort_openmp(a, size, sizeof(struct __data), compare);
+    end = omp_get_wtime();
+
+    message(1,"parallel sort time = %g s %d threads\n",end-start, omp_get_max_threads());
+    for(i=1; i<size; i++) {
+        if( a[i-1].dd[0] >a[i].dd[0] )
+            message(1,"BAD: %d %d %d\n",i,a[i-1].dd[0],a[i].dd[0]);
+        assert_true(a[i-1].dd[0] <= a[i].dd[0]);
+    }
+
+    srand48(8675309);
+    for(i = 0; i < size; i++)
+        a[i].dd[0] = (int) (size * drand48());
+
+    start = omp_get_wtime();
+    qsort(a, size, sizeof(struct __data), compare);
+    end = omp_get_wtime();
+
+    message(1, "serial (glibc) sort time = %g s\n",end-start);
+
+}
 static void test_openmpsort(void ** state) {
     int i;
     // set up array to be sorted
@@ -63,6 +103,7 @@ static void test_openmpsort(void ** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_openmpsort),
+        cmocka_unit_test(test_openmpsort_struct),
     };
     return cmocka_run_group_tests_mpi(tests, NULL, NULL);
 }

--- a/treewalk.c
+++ b/treewalk.c
@@ -311,7 +311,7 @@ treewalk_build_queue(TreeWalk * tw, int * active_set, int size) {
 #ifdef DEBUG
         /* check the uniqueness of ActiveParticle list. */
         /* FIXME: the sort may affect performance of treewalk */
-        qsort(queue, k, sizeof(int), cmpint);
+        qsort_openmp(queue, k, sizeof(int), cmpint);
         for(i = 0; i < k - 1; i ++) {
             if(queue[i] == queue[i+1]) {
                 endrun(8829, "A few particles are twicely active.");
@@ -749,7 +749,7 @@ static void fill_task_queue (TreeWalk * tw, struct ev_task * tq, int * pq, int l
         tq[i].place = pq[i];
         P[pq[i]].Evaluated = 0;
     }
-    // qsort(tq, length, sizeof(struct ev_task), ev_task_cmp_by_top_node);
+    // qsort_openmp(tq, length, sizeof(struct ev_task), ev_task_cmp_by_top_node);
 }
 
 /**********

--- a/walltime.c
+++ b/walltime.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "walltime.h"
+#include "openmpsort.h"
 
 static struct ClockTable * CT = NULL;
 
@@ -99,8 +100,8 @@ static void walltime_clock_insert(char * name) {
     strcpy(CT->C[CT->N].name, name);
     strcpy(CT->AC[CT->N].name, CT->C[CT->N].name);
     CT->N ++;
-    qsort(CT->C, CT->N, sizeof(struct Clock), clockcmp);
-    qsort(CT->AC, CT->N, sizeof(struct Clock), clockcmp);
+    qsort_openmp(CT->C, CT->N, sizeof(struct Clock), clockcmp);
+    qsort_openmp(CT->AC, CT->N, sizeof(struct Clock), clockcmp);
 }
 
 int walltime_clock(char * name) {


### PR DESCRIPTION
I noticed that system qsort, which for glibc is a merge sort, allocated O(n) temporary storage using malloc. This is not good for our memory fragmentation, especially as it does it under heavy thread contention. It is also unnecessary, as we already have temporary memory allocated for the parallelization, which we can re-use. 

I fixed this by copying glibc's qsort implementation of merge sort into openmpsort.c and renaming the temp variable. While I was there I also extended indirect sorting for large structures to the merge phase, which should help for the sort of struct particle_data in domain.c and reduces the maximum memory allocation. Another advantage of this is that a smart compiler with lto could possibly inline the comparison function.

We could probably make the sorting much faster by using introsort (which is in every C++ standard library) instead of glibc's mergesort, but I didn't bother (yet).