### PR TITLE
A bit more garbage

### DIFF
--- a/domain.c
+++ b/domain.c
@@ -173,19 +173,17 @@ void domain_decompose_full(void)
     if(domain_exchange(domain_layoutfunc))
         endrun(1929,"Could not exchange particles\n");
 
-    t1 = second();
-
-    message(0, "domain decomposition done. (took %g sec)\n", timediff(t0, t1));
-
     /*Do a garbage collection so that the slots are ordered
      *the same as the particles, garbage is at the end and all particles are in peano order.*/
     slots_gc_sorted();
 
-    walltime_measure("/Domain/Peano");
+    t1 = second();
+
+    message(0, "domain decomposition done. (took %g sec)\n", timediff(t0, t1));
 
     report_memory_usage("DOMAIN");
 
-    walltime_measure("/Domain/Misc");
+    walltime_measure("/Domain/Peano");
 
     /* this is a full decomposition, need to rebuild the force tree because all TopLeaves are out of date. */
     force_tree_rebuild();

--- a/exchange.c
+++ b/exchange.c
@@ -25,8 +25,8 @@ typedef struct {
     ExchangePlanEntry toGoSum;
     ExchangePlanEntry toGetSum;
 } ExchangePlan;
-/* 
- * 
+/*
+ *
  * exchange particles according to layoutfunc.
  * layoutfunc gives the target task of particle p.
 */
@@ -173,8 +173,7 @@ static int domain_exchange_once(int (*layoutfunc)(int p), ExchangePlan * plan)
     ta_free(toGoPtr);
     walltime_measure("/Domain/exchange/makebuf");
 
-    /* FIXME: This needs some benchmarking to pick a good value!
-     * Arguably this should be type-specific, but that feels like too much complexity.*/
+    /* This is a reasonable value which usually skips gc on the slots.*/
     slots_gc(0.1);
 
     walltime_measure("/Domain/exchange/garbage");
@@ -253,7 +252,7 @@ static int domain_exchange_once(int (*layoutfunc)(int p), ExchangePlan * plan)
             }
         }
         for(ptype = 0; ptype < 6; ptype ++) {
-            if(newPI[ptype] != 
+            if(newPI[ptype] !=
                 SlotsManager->info[ptype].size + plan->toGetOffset[src].slots[ptype]
               + plan->toGet[src].slots[ptype]) {
                 endrun(1, "N_slots mismatched\n");

--- a/exchange.c
+++ b/exchange.c
@@ -77,6 +77,8 @@ int domain_exchange(int (*layoutfunc)(int p)) {
 #pragma omp parallel for
     for(i = 0; i < NumPart; i++)
     {
+        if(P[i].IsGarbage)
+            continue;
         int target = layoutfunc(i);
         if(target != ThisTask)
             P[i].OnAnotherDomain = 1;
@@ -319,7 +321,6 @@ domain_build_plan(int (*layoutfunc)(int p), ExchangePlan * plan)
             break;
         }
         if(!P[n].OnAnotherDomain) continue;
-        if(P[n].IsGarbage) continue;
 
         int target = layoutfunc(n);
         if (target == ThisTask) continue;

--- a/exchange.c
+++ b/exchange.c
@@ -173,10 +173,14 @@ static int domain_exchange_once(int (*layoutfunc)(int p), ExchangePlan * plan)
     ta_free(toGoPtr);
     walltime_measure("/Domain/exchange/makebuf");
 
-    /* gc the slots here if we are low on slot memory. */
+    /*Find which slots to gc*/
     int compact[6] = {0};
     for(ptype = 0; ptype < 6; ptype++) {
+        /* gc if we are low on slot memory. */
         if (SlotsManager->info[ptype].size + plan->toGetSum.slots[ptype] > 0.95 * SlotsManager->info[ptype].maxsize)
+            compact[ptype] = 1;
+        /* gc if we had a very large exchange. */
+        if(plan->toGoSum.slots[ptype] > 0.1 * SlotsManager->info[ptype].size)
             compact[ptype] = 1;
     }
     slots_gc(compact);

--- a/exchange.c
+++ b/exchange.c
@@ -280,12 +280,12 @@ static int domain_exchange_once(int (*layoutfunc)(int p), ExchangePlan * plan)
         SlotsManager->info[ptype].size = newSlots[ptype];
     }
 
-    walltime_measure("/Domain/exchange/finalize");
-
 #ifdef DEBUG
     domain_test_id_uniqueness();
     slots_check_id_consistency();
 #endif
+    walltime_measure("/Domain/exchange/finalize");
+
     return 0;
 }
 

--- a/exchange.c
+++ b/exchange.c
@@ -183,6 +183,8 @@ static int domain_exchange_once(int (*layoutfunc)(int p), ExchangePlan * plan)
         if(plan->toGoSum.slots[ptype] > 0.1 * SlotsManager->info[ptype].size)
             compact[ptype] = 1;
     }
+    /*Make the slot compaction collective*/
+    MPI_Allreduce(MPI_IN_PLACE, &compact, 6, MPI_INT, MPI_LOR, MPI_COMM_WORLD);
     slots_gc(compact);
 
     walltime_measure("/Domain/exchange/garbage");

--- a/forcetree.c
+++ b/forcetree.c
@@ -74,15 +74,6 @@ static void
 force_insert_pseudo_particles(const struct TreeBuilder tb);
 
 static int
-force_tree_eh_slots_after_gc(EIBase * event, void * userdata)
-{
-    if(event->unused) {
-        force_tree_rebuild();
-    }
-    return 0;
-}
-
-static int
 force_tree_eh_slots_fork(EIBase * event, void * userdata)
 {
     /* after a fork, we will attach the new particle to the force tree. */
@@ -166,7 +157,6 @@ int force_tree_build(int npart)
 
     force_treeupdate_pseudos(All.MaxPart, tb);
 
-    event_listen(&EventSlotsAfterGC, force_tree_eh_slots_after_gc, NULL);
     event_listen(&EventSlotsFork, force_tree_eh_slots_fork, NULL);
     return Numnodestree;
 }
@@ -1121,7 +1111,6 @@ struct TreeBuilder force_treeallocate(int maxnodes, int maxpart, int first_node_
  */
 void force_tree_free(void)
 {
-    event_unlisten(&EventSlotsAfterGC, force_tree_eh_slots_after_gc, NULL);
     event_unlisten(&EventSlotsFork, force_tree_eh_slots_fork, NULL);
 
     myfree(Father);

--- a/forcetree.c
+++ b/forcetree.c
@@ -76,7 +76,9 @@ force_insert_pseudo_particles(const struct TreeBuilder tb);
 static int
 force_tree_eh_slots_after_gc(EIBase * event, void * userdata)
 {
-    endrun(1, "This shall not happen. Currently gc will break the tree. so we take care to have the tree deallocated before/after gc.\n");
+    if(event->unused) {
+        force_tree_rebuild();
+    }
     return 0;
 }
 

--- a/init.c
+++ b/init.c
@@ -68,9 +68,6 @@ void init(int RestartSnapNum)
     /*Read the snapshot*/
     petaio_read_snapshot(RestartSnapNum);
 
-    /* this ensures the initial slots are compact */
-    slots_gc();
-
     domain_test_id_uniqueness();
 
     check_omega();

--- a/run.c
+++ b/run.c
@@ -186,10 +186,9 @@ void run(void)
         if(WriteSnapshot || WriteFOF) {
             int snapnum = All.SnapshotFileCount++;
 
-            /* the accel may have created garbage -- collect them before checkpointing! */
-            force_tree_free();
-            slots_gc();
-            force_tree_rebuild();
+            /* The accel may have created garbage -- collect them before checkpointing!
+             * Tree will be auto-rebuilt if gc collected particles.*/
+            slots_gc(0.1);
 
             if(WriteSnapshot)
             {

--- a/run.c
+++ b/run.c
@@ -68,7 +68,7 @@ void run(void)
          * all bins except the zeroth are inactive and so we return 0 from this function.
          * This ensures we run the force calculation for the first timestep.
          */
-        All.Ti_Current = find_next_kick(All.Ti_Current, minTimeBin); 
+        All.Ti_Current = find_next_kick(All.Ti_Current, minTimeBin);
 
         /*Convert back to floating point time*/
         set_global_time(exp(loga_from_ti(All.Ti_Current)));
@@ -189,7 +189,8 @@ void run(void)
             /* The accel may have created garbage -- collect them before checkpointing!
              * Tree will be auto-rebuilt if gc collected particles,
              * but we should rebuild the active list.*/
-            if(slots_gc(0.1))
+            int compact[6] = {0};
+            if(slots_gc(compact))
                 rebuild_activelist(All.Ti_Current);
 
             if(WriteSnapshot)
@@ -198,7 +199,7 @@ void run(void)
                 /* FIXME: this doesn't allow saving fof without the snapshot yet. do it after allocator is merged */
 
                 /* write snapshot of particles */
-                savepositions(snapnum); 
+                savepositions(snapnum);
 
                 TimeLastOutput = All.CT.ElapsedTime;
             }

--- a/run.c
+++ b/run.c
@@ -187,11 +187,12 @@ void run(void)
             int snapnum = All.SnapshotFileCount++;
 
             /* The accel may have created garbage -- collect them before checkpointing!
-             * Tree will be auto-rebuilt if gc collected particles,
-             * but we should rebuild the active list.*/
+             * If we do collect, rebuild tree and active list.*/
             int compact[6] = {0};
-            if(slots_gc(compact))
+            if(slots_gc(compact)) {
+                force_tree_rebuild();
                 rebuild_activelist(All.Ti_Current);
+            }
 
             if(WriteSnapshot)
             {

--- a/run.c
+++ b/run.c
@@ -187,8 +187,10 @@ void run(void)
             int snapnum = All.SnapshotFileCount++;
 
             /* The accel may have created garbage -- collect them before checkpointing!
-             * Tree will be auto-rebuilt if gc collected particles.*/
-            slots_gc(0.1);
+             * Tree will be auto-rebuilt if gc collected particles,
+             * but we should rebuild the active list.*/
+            if(slots_gc(0.1))
+                rebuild_activelist(All.Ti_Current);
 
             if(WriteSnapshot)
             {

--- a/slotsmanager.c
+++ b/slotsmanager.c
@@ -185,6 +185,19 @@ static int
 slots_gc_mark()
 {
     int i;
+#ifdef DEBUG
+    int ptype;
+    /*Initially set all reverse links to an obviously invalid value*/
+    for(ptype = 0; ptype < 6; ptype++)
+    {
+        if(!SLOTS_ENABLED(ptype))
+            continue;
+        #pragma omp parallel for
+        for(i = 0; i < SlotsManager->info[ptype].size; i++) {
+            BASESLOT_PI(i, ptype)->gc.ReverseLink = All.MaxPart + 100;
+        }
+    }
+#endif
 
 #pragma omp parallel for
     for(i = 0; i < NumPart; i++) {

--- a/slotsmanager.c
+++ b/slotsmanager.c
@@ -134,10 +134,6 @@ slots_gc(int * compact_slots)
 
     MPI_Allreduce(MPI_IN_PLACE, &tree_invalid, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
-    EISlotsAfterGC event = {{tree_invalid}};
-
-    event_emit(&EventSlotsAfterGC, (EIBase*) &event);
-
     return tree_invalid;
 }
 
@@ -407,10 +403,6 @@ slots_gc_sorted()
 #ifdef DEBUG
     slots_check_id_consistency();
 #endif
-
-    /*Rebuild the tree if still allocated*/
-    EISlotsAfterGC event = {{1}};
-    event_emit(&EventSlotsAfterGC, (EIBase*) &event);
 }
 
 void

--- a/slotsmanager.c
+++ b/slotsmanager.c
@@ -318,11 +318,11 @@ slots_gc_slots(double defrag_frac)
             slots_gc_sweep(ptype);
             slots_gc_collect(ptype);
         }
-#ifdef DEBUG
-        slots_check_id_consistency();
-#endif
     }
 
+#ifdef DEBUG
+    slots_check_id_consistency();
+#endif
     for(ptype = 0; ptype < 6; ptype ++) {
         sumup_large_ints(1, &SlotsManager->info[ptype].size, &total1[ptype]);
 

--- a/slotsmanager.c
+++ b/slotsmanager.c
@@ -172,11 +172,12 @@ slots_gc_compact(int used, int ptype, size_t size)
             }
         /*If no more non-garbage particles, don't both copying, just add a skip*/
         if(src == used) {
-            ngc++;
+            ngc += src - lastgc;
             break;
         }
         /*Destination is shifted already*/
         int dest = lastgc - ngc;
+
         nextgc = used;
         /*Find another garbage particle*/
         for(i = src+1; i < used; i++)
@@ -293,7 +294,7 @@ slots_gc_collect(int ptype)
 
 #ifdef DEBUG
         if(BASESLOT_PI(i, ptype)->IsGarbage) {
-            endrun(1, "Shall not happend\n");
+            endrun(1, "Shall not happen: i=%d ptype = %d\n", i,ptype);
         }
 #endif
 

--- a/slotsmanager.c
+++ b/slotsmanager.c
@@ -450,7 +450,7 @@ slots_check_id_consistency()
             endrun(1, "slot PI consistency failed2\n");
         }
         if(BASESLOT(i)->ID != P[i].ID) {
-            endrun(1, "slot id consistency failed2\n");
+            endrun(1, "slot id consistency failed2: i=%d P.ID = %ld SLOT.ID=%ld\n",i, P[i].ID, BASESLOT(i)->ID);
         }
         used[P[i].Type] ++;
     }

--- a/slotsmanager.c
+++ b/slotsmanager.c
@@ -292,7 +292,7 @@ slots_gc_slots(double defrag_frac)
     int64_t total0[6];
     int64_t total1[6];
 
-    int disabled = 1;
+    int disabled[6] = {1}, all_disabled = 1;
     for(ptype = 0; ptype < 6; ptype ++) {
         sumup_large_ints(1, &SlotsManager->info[ptype].size, &total0[ptype]);
     }
@@ -303,16 +303,17 @@ slots_gc_slots(double defrag_frac)
     /*Disable gc if there is insufficient garbage (or no slots are used)*/
     for(ptype = 0; ptype < 6; ptype ++) {
         int defrag = 1 + defrag_frac * SlotsManager->info[ptype].size;
-        if(SlotsManager->info[ptype].garbage >= defrag)
-            disabled = 0;
+        if(SlotsManager->info[ptype].garbage >= defrag) {
+            disabled[ptype] = 0;
+            all_disabled = 0;
+        }
     }
 
-    if(!disabled) {
+    if(!all_disabled) {
         slots_gc_mark();
 
         for(ptype = 0; ptype < 6; ptype++) {
-            int defrag = 1 + defrag_frac * SlotsManager->info[ptype].size;
-            if(SlotsManager->info[ptype].garbage < defrag)
+            if(disabled[ptype])
                 continue;
             slots_gc_sweep(ptype);
             slots_gc_collect(ptype);

--- a/slotsmanager.h
+++ b/slotsmanager.h
@@ -10,9 +10,7 @@ extern struct slots_manager_type {
         int size; /* currently used slots*/
         size_t elsize; /* itemsize */
         int enabled;
-        int garbage;
     } info[6];
-    int garbage;
 } SlotsManager[1];
 
 /* shortcuts for accessing different slots directly by the index */
@@ -38,7 +36,7 @@ void slots_mark_garbage(int i);
 void slots_setup_topology();
 void slots_setup_id();
 int slots_fork(int parent, int ptype);
-int slots_gc(double defrag_frac);
+int slots_gc(int * compact_slots);
 void slots_gc_sorted(void);
 void slots_reserve(int atleast[6]);
 void slots_check_id_consistency();

--- a/slotsmanager.h
+++ b/slotsmanager.h
@@ -47,8 +47,4 @@ typedef struct {
     int child;
 } EISlotsFork;
 
-typedef struct {
-    EIBase base;
-} EISlotsAfterGC;
-
 #endif

--- a/slotsmanager.h
+++ b/slotsmanager.h
@@ -10,7 +10,9 @@ extern struct slots_manager_type {
         int size; /* currently used slots*/
         size_t elsize; /* itemsize */
         int enabled;
+        int garbage;
     } info[6];
+    int garbage;
 } SlotsManager[1];
 
 /* shortcuts for accessing different slots directly by the index */
@@ -36,10 +38,10 @@ void slots_mark_garbage(int i);
 void slots_setup_topology();
 void slots_setup_id();
 int slots_fork(int parent, int ptype);
-int slots_gc(void);
+int slots_gc(double defrag_frac);
+void slots_gc_sorted(void);
 void slots_reserve(int atleast[6]);
 void slots_check_id_consistency();
-
 
 typedef struct {
     EIBase base;

--- a/tests/test_slotsmanager.c
+++ b/tests/test_slotsmanager.c
@@ -1,4 +1,3 @@
-
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -6,11 +5,11 @@
 #include <math.h>
 #include <mpi.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 #include <gsl/gsl_rng.h>
 #include "allvars.h"
 #include "domain.h"
-#include "peano.c"
 #include "slotsmanager.h"
 #include "mymalloc.h"
 #include "stub.h"

--- a/tests/test_slotsmanager.c
+++ b/tests/test_slotsmanager.c
@@ -59,10 +59,12 @@ test_slots_gc(void **state)
 {
     setup_particles(state);
     int i;
+    int compact[6];
     for(i = 0; i < 6; i ++) {
         slots_mark_garbage(128 * i);
+        compact[i] = 1;
     }
-    slots_gc(0);
+    slots_gc(compact);
     assert_int_equal(NumPart, 127 * i);
 
     assert_int_equal(SlotsManager->info[0].size, 127);

--- a/tests/test_slotsmanager.c
+++ b/tests/test_slotsmanager.c
@@ -62,7 +62,26 @@ test_slots_gc(void **state)
     for(i = 0; i < 6; i ++) {
         slots_mark_garbage(128 * i);
     }
-    slots_gc();
+    slots_gc(0);
+    assert_int_equal(NumPart, 127 * i);
+
+    assert_int_equal(SlotsManager->info[0].size, 127);
+    assert_int_equal(SlotsManager->info[4].size, 127);
+    assert_int_equal(SlotsManager->info[5].size, 127);
+
+    teardown_particles(state);
+    return;
+}
+
+static void
+test_slots_gc_sorted(void **state)
+{
+    setup_particles(state);
+    int i;
+    for(i = 0; i < 6; i ++) {
+        slots_mark_garbage(128 * i);
+    }
+    slots_gc_sorted();
     assert_int_equal(NumPart, 127 * i);
 
     assert_int_equal(SlotsManager->info[0].size, 127);
@@ -138,6 +157,7 @@ test_slots_fork(void **state)
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_slots_gc),
+        cmocka_unit_test(test_slots_gc_sorted),
         cmocka_unit_test(test_slots_reserve),
         cmocka_unit_test(test_slots_fork),
     };

--- a/timestep.c
+++ b/timestep.c
@@ -729,6 +729,8 @@ int rebuild_activelist(inttime_t Ti_Current)
 
         if(is_timebin_active(bin, Ti_Current))
         {
+            if(P[i].IsGarbage)
+                endrun(2,"Trying to make particle %d active, but it is garbage!\n", i);
             ActiveParticle[NumActiveParticle] = i;
             NumActiveParticle++;
         }


### PR DESCRIPTION
Continuing in our series of improving the garbage collection - this is a series with a few more tweaks. The differences are actually rather slight. The main commit is 9ba9d25, which adds a new garbage collection algorithm which is O(n) when compacting the slots, and preserves the (peano) order of the particles. This also lets the non-slot-compacting part avoid changing the slot array entirely, but because more data is moved, the base gc is slower. On my machine this works out to exactly the same time taken doing GC. The slot gc might be faster but with the default parameters it doesn't run very often. 
I also moved the peano sort into slotmanager and added a slot sort after it.

The main advantage is that treebuild is 20% faster on average, because the ordered particles make it easier for the optimizations to kick in. The better ordering makes no difference to the treewalk. Overall this made surprisingly little difference, which may suggest we have optimized as much as we can.