### PR TITLE
split ioctl stuff to HCI(human-computer-interaction).

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -16,7 +16,7 @@ LIBS   = -lm $(GSL_LIBS) -Ldepends/lib $(BUNDLEDLIBS)
 OPTIONS = $(OPTIMIZE) $(OPT)
 
 GADGET_OBJS =  \
-	 gdbtools.o \
+	 gdbtools.o hci.o\
 	 fof.o fofpetaio.o petaio.o \
 	 param.o paramset.o \
 	 domain.o exchange.o slotsmanager.o allvars.o main.o \
@@ -50,7 +50,7 @@ ICOBJECTS   = genic/main.o genic/power.o genic/allvars.o genic/params.o \
 
 
 INCL = \
-config-migrate.h  densitykernel.h  endrun.h    forcetree.h  interp.h event.h  \
+config-migrate.h  densitykernel.h  endrun.h    forcetree.h  interp.h event.h hci.h \
 mymalloc.h    paramset.h  petapm.h         proto.h    timebinmgr.h  treewalk.h \
 allvars.h    cooling.h         domain.h         exchange.h  slotsmanager.h     \
  openmpsort.h  peano.h     physconst.h      sfr_eff.h  timefac.h     utils-string.h \

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -14,6 +14,7 @@
 #
 ##
 TESTED = \
+	hci \
 	slotsmanager \
 	interp \
 	powerspectrum \

--- a/begrun.c
+++ b/begrun.c
@@ -22,6 +22,8 @@
 #include "endrun.h"
 #include "utils-string.h"
 #include "system.h"
+#include "hci.h"
+
 #include "kspace-neutrinos/delta_tot_table.h"
 
 /*! \file begrun.c
@@ -48,6 +50,7 @@ extern _transfer_init_table transfer_init;
 void begrun(int RestartSnapNum)
 {
 
+    hci_init(HCI_DEFAULT_MANAGER, All.OutputDir, All.TimeLimitCPU, All.AutoSnapshotTime);
     slots_init();
 
     petaio_init();

--- a/endrun.c
+++ b/endrun.c
@@ -74,3 +74,4 @@ void message(int where, const char * fmt, ...)
         }
     }
 }
+

--- a/forcetree.c
+++ b/forcetree.c
@@ -146,7 +146,7 @@ int force_tree_build(int npart)
             if(All.TreeAllocFactor > 5.0)
             {
                 message(0, "An excessively large number of tree nodes were required, stopping with particle dump.\n");
-                savepositions(999999);
+                dump_snapshot();
                 endrun(0, "Too many tree nodes, snapshot saved.");
             }
         }

--- a/hci.c
+++ b/hci.c
@@ -79,13 +79,13 @@ hci_query_filesystem(HCIManager * manager, char * filename)
     if(ThisTask == 0) {
         char * fullname = fastpm_strdup_printf("%s/%s", manager->prefix, filename);
         content = fastpm_file_get_content(fullname);
-        free(fullname);
         if(content) {
             size = strlen(content);
-            unlink(fullname);
+            remove(fullname);
         } else {
             size = -1;
         }
+        free(fullname);
     }
     MPI_Bcast(&size, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
@@ -130,16 +130,11 @@ hci_query_auto_checkpoint(HCIManager * manager)
     if(now - manager->TimeLastCheckPoint >= manager->AutoCheckPointTime) {
         return calloc(32, 1);
     }
+    return NULL;
 }
 
 /*
- * the return value is non-zero if the mainloop shall break
- * the function doesn't always return; if a termination is requested it will
- * immediately trigger an endrun.
- *
- * The control is provided by the 
- * The termination request is to avoid accidentally
- * terminating during IO.
+ * the return value is non-zero if the mainloop shall break.
  * */
 int
 hci_query(HCIManager * manager, HCIAction * action)
@@ -151,9 +146,18 @@ hci_query(HCIManager * manager, HCIAction * action)
 
     char * request;
 
+    /*Will we run out of time by the next PM step?*/
+    if(request = hci_query_timeout(manager)) {
+        message(0, "Stopping due to TimeLimitCPU, dumping a CheckPoint.\n");
+        action->type = HCI_TIMEOUT;
+        action->write_snapshot = 1;
+        free(request);
+        return 1;
+    }
+
     if(request = hci_query_filesystem(manager, "ioctl"))
     {
-        action->type = IOCTL;
+        action->type = HCI_IOCTL;
         //update_IO_params(request);
         free(request);
         return 0;
@@ -162,10 +166,9 @@ hci_query(HCIManager * manager, HCIAction * action)
     if(request = hci_query_filesystem(manager, "checkpoint"))
     {
         message(0, "human controlled stop with checkpoint at next PM.\n");
-        action->type = CHECKPOINT;
+        action->type = HCI_CHECKPOINT;
         /* Write when the PM timestep completes*/
         action->write_snapshot = 1;
-        action->write_fof = 0;
         free(request);
         manager->TimeLastCheckPoint = hci_now(manager);
         return 0;
@@ -174,9 +177,8 @@ hci_query(HCIManager * manager, HCIAction * action)
     /* Is the stop-file present? If yes, interrupt the run with a snapshot. */
     if(request = hci_query_filesystem(manager, "stop"))
     {
-        action->type = STOP;
+        action->type = HCI_STOP;
         action->write_snapshot = 1;
-        action->write_fof = 0;
         free(request);
         return 1;
     }
@@ -184,11 +186,10 @@ hci_query(HCIManager * manager, HCIAction * action)
     /* Is the terminate-file present? If yes, interrupt the run immediately. */
     if(request = hci_query_filesystem(manager, "terminate"))
     {
-        action->type = TERMINATE;
+        /* the caller shall take care of immediate termination.
+         * This action is better than KILL as it avoids corrupt/incomplete snapshot files.*/
+        action->type = HCI_TERMINATE;
         action->write_snapshot = 0;
-        action->write_fof = 0;
-        endrun(-1, "Human requested termination triggered.\n");
-        /* never reach here */
         free(request);
         return 1;
     }
@@ -196,24 +197,14 @@ hci_query(HCIManager * manager, HCIAction * action)
     if(request = hci_query_auto_checkpoint(manager))
     {
         message(0, "Auto checkpoint due to AutoCheckPointTime.\n");
-        action->type = AUTO_CHECKPOINT;
+        action->type = HCI_AUTO_CHECKPOINT;
         /* Write when the PM timestep completes*/
         action->write_snapshot = 1;
-        action->write_fof = 0;
         manager->TimeLastCheckPoint = hci_now(manager);
         free(request);
         return 0;
     }
-
-    /*Will we run out of time by the next PM step?*/
-    if(request = hci_query_timeout(manager)) {
-        message(0, "Stopping due to TimeLimitCPU, dumping a CheckPoint.\n");
-        action->type = TIMEOUT;
-        action->write_snapshot = 1;
-        action->write_fof = 0;
-        free(request);
-        return 1;
-    }
-
+    action->type = HCI_NO_ACTION;
+    action->write_snapshot = 0;
     return 0;
 }

--- a/hci.c
+++ b/hci.c
@@ -58,9 +58,9 @@ static
 void hci_update_query_timer(HCIManager * manager)
 {
     double e = hci_now(manager);
-    e = e - manager->timer_query_begin;
-    if(e > manager->LongestTimeBetweenQueries)
-        manager->LongestTimeBetweenQueries = e;
+    double g = e - manager->timer_query_begin;
+    if(g > manager->LongestTimeBetweenQueries)
+        manager->LongestTimeBetweenQueries = g;
 
     manager->timer_query_begin = e;
 }
@@ -152,7 +152,7 @@ hci_query(HCIManager * manager, HCIAction * action)
     /* Will we run out of time by the query ? highest priority.
      */
     if(request = hci_query_timeout(manager)) {
-        message(0, "Stopping due to TimeLimitCPU, dumping a CheckPoint.\n");
+        message(0, "HCI: Stopping due to TimeLimitCPU, dumping a CheckPoint\n.");
         action->type = HCI_TIMEOUT;
         action->write_snapshot = 1;
         free(request);
@@ -161,6 +161,7 @@ hci_query(HCIManager * manager, HCIAction * action)
 
     if(request = hci_query_filesystem(manager, "ioctl"))
     {
+        message(0, "HCI: updating io parameters, this is not supported yet.\n");
         //update_IO_params(request);
         free(request);
         return 0;
@@ -168,7 +169,7 @@ hci_query(HCIManager * manager, HCIAction * action)
 
     if(request = hci_query_filesystem(manager, "checkpoint"))
     {
-        message(0, "human controlled stop with checkpoint at next PM.\n");
+        message(0, "HCI: human controlled stop with checkpoint at next PM.\n");
         action->type = HCI_CHECKPOINT;
         /* will write checkpoint in this PM timestep */
         action->write_snapshot = 1;
@@ -190,6 +191,7 @@ hci_query(HCIManager * manager, HCIAction * action)
     /* Is the terminate-file present? If yes, interrupt the run immediately. */
     if(request = hci_query_filesystem(manager, "terminate"))
     {
+        message(0, "HCI: human triggered termination.\n");
         /* the caller shall take care of immediate termination.
          * This action is better than KILL as it avoids corrupt/incomplete snapshot files.*/
         action->type = HCI_TERMINATE;
@@ -201,7 +203,7 @@ hci_query(HCIManager * manager, HCIAction * action)
     /* lower priority */
     if(request = hci_query_auto_checkpoint(manager))
     {
-        message(0, "Auto checkpoint due to AutoCheckPointTime.\n");
+        message(0, "HCI: Auto checkpoint due to AutoCheckPointTime.\n");
         action->type = HCI_AUTO_CHECKPOINT;
         /* Write when the PM timestep completes*/
         action->write_snapshot = 1;
@@ -210,6 +212,7 @@ hci_query(HCIManager * manager, HCIAction * action)
         return 0;
     }
 
+    message(0, "HCI: Nothing happened. \n");
     /* nothing really happened. */
     action->type = HCI_NO_ACTION;
     action->write_snapshot = 0;

--- a/hci.c
+++ b/hci.c
@@ -38,6 +38,13 @@ hci_init(HCIManager * manager, char * prefix, double WallClockTimeLimit, double 
     manager->LongestTimeBetweenQueries = 0;
 }
 
+void
+hci_action_init(HCIAction * action)
+{
+    action->type = HCI_NO_ACTION;
+    action->write_snapshot = 0;
+}
+
 /* override the result of hci_now; for unit testing -- we can't rely on MPI_Wtime there! 
  * this function can be called before hci_init. */
 int
@@ -147,6 +154,8 @@ hci_query_auto_checkpoint(HCIManager * manager, char ** request)
 int
 hci_query(HCIManager * manager, HCIAction * action)
 {
+    hci_action_init(action);
+
     /* measure time since last query */
     hci_update_query_timer(manager);
 
@@ -222,9 +231,6 @@ hci_query(HCIManager * manager, HCIAction * action)
     }
 
     message(0, "HCI: Nothing happened. \n");
-    /* nothing really happened. */
-    action->type = HCI_NO_ACTION;
-    action->write_snapshot = 0;
     return 0;
 }
 

--- a/hci.c
+++ b/hci.c
@@ -1,0 +1,205 @@
+#include <mpi.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "endrun.h"
+#include "utils-string.h"
+#include "hci.h"
+
+HCIManager HCI_DEFAULT_MANAGER[1];
+
+static double
+hci_now()
+{
+    /* must be consistent between all ranks. */
+    double e = MPI_Wtime();
+    MPI_Bcast(&e, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+    return e;
+}
+
+void
+hci_init(HCIManager * manager, char * prefix, double WallClockTimeLimit, double AutoCheckPointTime)
+{
+    manager->prefix = strdup(prefix);
+    manager->timer_begin = hci_now();
+    manager->timer_query_begin = manager->timer_begin;
+
+    manager->WallClockTimeLimit = WallClockTimeLimit;
+    manager->AutoCheckPointTime = AutoCheckPointTime;
+    manager->LongestTimeBetweenQueries = 0;
+}
+
+static double
+hci_get_elapsed_time(HCIManager * manager)
+{
+    double e = hci_now() - manager->timer_begin;
+    return e;
+}
+
+static
+void hci_update_query_timer(HCIManager * manager)
+{
+    double e = hci_now();
+    e = e - manager->timer_query_begin;
+    if(e > manager->LongestTimeBetweenQueries)
+        manager->LongestTimeBetweenQueries = e;
+
+    manager->timer_query_begin = e;
+}
+
+/*
+ * query the filesystem for HCI commands;
+ * returns the content of the file or NULL; collectively
+ * */
+static char *
+hci_query_filesystem(HCIManager * manager, char * filename)
+{
+    int ThisTask;
+    int NTask;
+    MPI_Comm_size(MPI_COMM_WORLD, &NTask);
+    MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
+    int size = 0;
+    char * content = NULL;
+    if(ThisTask == 0) {
+        char * fullname = fastpm_strdup_printf("%s/%s", manager->prefix, filename);
+        content = fastpm_file_get_content(fullname);
+        free(fullname);
+        if(content) {
+            size = strlen(content);
+            unlink(fullname);
+        } else {
+            size = -1;
+        }
+    }
+    MPI_Bcast(&size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    if(size != -1) {
+        if(ThisTask != 0) {
+            content = calloc(size + 1, 1);
+        }
+        MPI_Bcast(content, size+1, MPI_BYTE, 0, MPI_COMM_WORLD);
+    } else {
+        content == NULL;
+    }
+
+    return content;
+}
+
+static char *
+hci_query_timeout(HCIManager * manager)
+{
+    double now = hci_get_elapsed_time(manager);
+    /*
+     * factor 0.9 is a safety tolerance
+     * for possible inconsistency between measured time and the true wallclock
+     *
+     * If there likely isn't time for a new query, then we shall timeout as well.
+     * */
+
+    if (now + manager->LongestTimeBetweenQueries < manager->WallClockTimeLimit * 0.9) {
+        return NULL;
+    }
+
+    /* any empty string would work. */
+    return calloc(32, 1);
+}
+
+static char *
+hci_query_auto_checkpoint(HCIManager * manager)
+{
+    /*How long since the last checkpoint?*/
+    if(manager->AutoCheckPointTime <= 0) return NULL;
+
+    double now = hci_get_elapsed_time(manager);
+    if(now - manager->TimeLastCheckPoint >= manager->AutoCheckPointTime) {
+        return calloc(32, 1);
+    }
+}
+
+/*
+ * the return value is non-zero if the mainloop shall break
+ * the function doesn't always return; if a termination is requested it will
+ * immediately trigger an endrun.
+ *
+ * The control is provided by the 
+ * The termination request is to avoid accidentally
+ * terminating during IO.
+ * */
+int
+hci_query(HCIManager * manager, HCIAction * action)
+{
+    /* measure time since last query */
+    hci_update_query_timer(manager);
+
+    /* Check whether we need to interrupt the run */
+
+    char * request;
+
+    if(request = hci_query_filesystem(manager, "ioctl"))
+    {
+        action->type = IOCTL;
+        //update_IO_params(request);
+        free(request);
+        return 0;
+    }
+
+    if(request = hci_query_filesystem(manager, "checkpoint"))
+    {
+        message(0, "human controlled stop with checkpoint at next PM.\n");
+        action->type = CHECKPOINT;
+        /* Write when the PM timestep completes*/
+        action->write_snapshot = 1;
+        action->write_fof = 0;
+        free(request);
+        manager->TimeLastCheckPoint = hci_now();
+        return 0;
+    }
+
+    /* Is the stop-file present? If yes, interrupt the run with a snapshot. */
+    if(request = hci_query_filesystem(manager, "stop"))
+    {
+        action->type = STOP;
+        action->write_snapshot = 1;
+        action->write_fof = 0;
+        free(request);
+        return 1;
+    }
+
+    /* Is the terminate-file present? If yes, interrupt the run immediately. */
+    if(request = hci_query_filesystem(manager, "terminate"))
+    {
+        action->type = TERMINATE;
+        action->write_snapshot = 0;
+        action->write_fof = 0;
+        endrun(-1, "Human requested termination triggered.\n");
+        /* never reach here */
+        free(request);
+        return 1;
+    }
+
+    if(request = hci_query_auto_checkpoint(manager))
+    {
+        message(0, "Auto checkpoint due to AutoCheckPointTime.\n");
+        action->type = AUTO_CHECKPOINT;
+        /* Write when the PM timestep completes*/
+        action->write_snapshot = 1;
+        action->write_fof = 0;
+        manager->TimeLastCheckPoint = hci_now();
+        free(request);
+        return 0;
+    }
+
+    /*Will we run out of time by the next PM step?*/
+    if(request = hci_query_timeout(manager)) {
+        message(0, "Stopping due to TimeLimitCPU, dumping a CheckPoint.\n");
+        action->type = TIMEOUT;
+        action->write_snapshot = 1;
+        action->write_fof = 0;
+        free(request);
+        return 1;
+    }
+
+    return 0;
+}

--- a/hci.h
+++ b/hci.h
@@ -34,6 +34,9 @@ extern HCIManager HCI_DEFAULT_MANAGER[];
 void
 hci_init(HCIManager * manager, char * prefix, double TimeLimitCPU, double AutoCheckPointTime);
 
+void
+hci_action_init(HCIAction * action);
+
 int
 hci_query(HCIManager * manager, HCIAction * action);
 

--- a/hci.h
+++ b/hci.h
@@ -1,0 +1,35 @@
+typedef struct HCIManager {
+    /* private: */
+    char * prefix;
+    double TimeLastCheckPoint;
+    double AutoCheckPointTime;
+    double LongestTimeBetweenQueries;
+    double WallClockTimeLimit;
+    double timer_query_begin;
+    double timer_begin;
+} HCIManager;
+
+enum HCIActionType {
+    NO_ACTION = 0,
+    STOP = 1,
+    TIMEOUT = 2,
+    AUTO_CHECKPOINT = 3,
+    CHECKPOINT = 4,
+    TERMINATE = 5,
+    IOCTL = 6,
+};
+
+typedef struct HCIAction
+{
+    enum HCIActionType type;
+    int write_snapshot;
+    int write_fof;
+} HCIAction;
+
+extern HCIManager HCI_DEFAULT_MANAGER[];
+
+void
+hci_init(HCIManager * manager, char * prefix, double TimeLimitCPU, double AutoCheckPointTime);
+
+int
+hci_query(HCIManager * manager, HCIAction * action);

--- a/hci.h
+++ b/hci.h
@@ -14,20 +14,19 @@ typedef struct HCIManager {
 } HCIManager;
 
 enum HCIActionType {
-    NO_ACTION = 0,
-    STOP = 1,
-    TIMEOUT = 2,
-    AUTO_CHECKPOINT = 3,
-    CHECKPOINT = 4,
-    TERMINATE = 5,
-    IOCTL = 6,
+    HCI_NO_ACTION = 0,
+    HCI_STOP = 1,
+    HCI_TIMEOUT = 2,
+    HCI_AUTO_CHECKPOINT = 3,
+    HCI_CHECKPOINT = 4,
+    HCI_TERMINATE = 5,
+    HCI_IOCTL = 6,
 };
 
 typedef struct HCIAction
 {
     enum HCIActionType type;
     int write_snapshot;
-    int write_fof;
 } HCIAction;
 
 extern HCIManager HCI_DEFAULT_MANAGER[];

--- a/hci.h
+++ b/hci.h
@@ -7,6 +7,10 @@ typedef struct HCIManager {
     double WallClockTimeLimit;
     double timer_query_begin;
     double timer_begin;
+
+    /* for debugging: */
+    int OVERRIDE_NOW;
+    double _now;
 } HCIManager;
 
 enum HCIActionType {
@@ -33,3 +37,6 @@ hci_init(HCIManager * manager, char * prefix, double TimeLimitCPU, double AutoCh
 
 int
 hci_query(HCIManager * manager, HCIAction * action);
+
+int
+hci_override_now(HCIManager * manager, double now);

--- a/proto.h
+++ b/proto.h
@@ -16,7 +16,9 @@ void hydro_force(void);
 void init(int RestartSnapNum);
 void run(void);
 void runtests(void);
-void savepositions(int num);
+
+void write_checkpoint(int write_snapshot, int write_fof);
+void dump_snapshot(void);
 int find_last_snapnum();
 
 void long_range_init(void);

--- a/run.c
+++ b/run.c
@@ -84,9 +84,12 @@ void run(void)
             int r = hci_query(HCI_DEFAULT_MANAGER, action);
 
             unplanned_sync->write_snapshot = action->write_snapshot;
-            unplanned_sync->write_fof = action->write_fof;
+            unplanned_sync->write_fof = 0;
             /* if hci requests a break, pretend we are out of syncpoints */
             if(r != 0) next_sync = NULL;
+            if(action->type == HCI_TERMINATE) {
+                endrun(0, "Human triggered termination\n");
+            }
         }
         /* Sync positions of all particles */
         drift_all_particles(All.Ti_Current);

--- a/run.c
+++ b/run.c
@@ -78,7 +78,7 @@ void run(void)
         int stop = 0;
 
         if(is_PM) {
-            /* query other requests only on PM step. */
+            /* query HCI requests only on PM step; where kick and drifts are synced */
             stop = hci_query(HCI_DEFAULT_MANAGER, action);
 
             if(action->type == HCI_TERMINATE) {
@@ -132,7 +132,6 @@ void run(void)
         if(planned_sync) {
             WriteSnapshot |= planned_sync->write_snapshot;
             WriteFOF |= planned_sync->write_fof;
-
         }
 
         if(is_PM) { /* the if here is unnecessary but to signify checkpointing occurs only at PM steps. */

--- a/run.c
+++ b/run.c
@@ -41,7 +41,7 @@ void run(void)
     /*Minimum occupied timebin. Initially (but never again) zero*/
     int minTimeBin = 0;
     /*Is gas physics enabled?*/
-    int GasEnabled = All.NTotalInit[0];
+    int GasEnabled = All.NTotalInit[0] > 0;
 
     walltime_measure("/Misc");
 
@@ -195,7 +195,7 @@ void compute_accelerations(int is_PM, int FirstStep, int GasEnabled)
 
     /* We do this first so that the density is up to date for
      * adaptive gravitational softenings. */
-    if(GasEnabled > 0)
+    if(GasEnabled)
     {
         /***** density *****/
         message(0, "Start density computation...\n");

--- a/run.c
+++ b/run.c
@@ -191,34 +191,6 @@ void run(void)
     }
 }
 
-static void
-update_IO_params(const char * ioctlfname)
-{
-    if(ThisTask == 0) {
-        FILE * fd = fopen(ioctlfname, "r");
-         /* there is an ioctl file, parse it and update
-          * All.NumPartPerFile
-          * All.NumWriters
-          */
-        size_t n = 0;
-        char * line = NULL;
-        while(-1 != getline(&line, &n, fd)) {
-            sscanf(line, "BytesPerFile %lu", &All.IO.BytesPerFile);
-            sscanf(line, "NumWriters %d", &All.IO.NumWriters);
-        }
-        free(line);
-        fclose(fd);
-    }
-
-    MPI_Bcast(&All.IO, sizeof(All.IO), MPI_BYTE, 0, MPI_COMM_WORLD);
-    message(0, "New IO parameter recieved from %s:"
-               "NumPartPerfile %d"
-               "NumWriters %d\n",
-            ioctlfname,
-            All.IO.BytesPerFile,
-            All.IO.NumWriters);
-}
-
 /*! This routine computes the accelerations for all active particles.  First, the gravitational forces are
  * computed. This also reconstructs the tree, if needed, otherwise the drift/kick operations have updated the
  * tree to make it fullu usable at the current time.

--- a/run.c
+++ b/run.c
@@ -87,8 +87,9 @@ void run(void)
             unplanned_sync->write_fof = 0;
             /* if hci requests a break, pretend we are out of syncpoints */
             if(r != 0) next_sync = NULL;
+
             if(action->type == HCI_TERMINATE) {
-                endrun(0, "Human triggered termination\n");
+                endrun(0, "Human triggered termination.\n");
             }
         }
         /* Sync positions of all particles */

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -51,7 +51,7 @@ domain_get_topleaf(const peano_t key) {
     return no;
 }
 
-void savepositions(int n, int i){}
+void dump_snapshot() { }
 
 /*End dummies*/
 

--- a/tests/test_hci.c
+++ b/tests/test_hci.c
@@ -1,0 +1,184 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+#include "stub.h"
+
+#include "hci.h"
+#include "utils-string.h"
+#include "endrun.h"
+
+char prefix[1024] = "XXXXXXXX";
+
+static int
+touch(char * prefix, char * b)
+{
+    char * fn = fastpm_strdup_printf("%s/%s", prefix, b);
+    FILE * fp = fopen(fn, "w");
+    free(fn);
+    fclose(fp);
+}
+
+static int
+exists(char * prefix, char * b)
+{
+    char * fn = fastpm_strdup_printf("%s/%s", prefix, b);
+    FILE * fp = fopen(fn, "r");
+    free(fn);
+    if(fp) {
+        fclose(fp);
+        return 1;
+    }
+    return 0;
+}
+
+HCIManager manager[1] = {
+    {.OVERRIDE_NOW = 1, ._now = 0.0}};
+
+
+static void
+test_hci_no_action(void ** state)
+{
+    HCIAction action[1];
+
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    hci_query(manager, action);
+    assert_int_equal(action->type, HCI_NO_ACTION);
+    assert_int_equal(action->write_snapshot, 0);
+
+}
+
+static void
+test_hci_auto_checkpoint(void ** state)
+{
+    HCIAction action[1];
+
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    hci_override_now(manager, 0.0);
+    hci_query(manager, action);
+
+    hci_override_now(manager, 1.0);
+    hci_query(manager, action);
+
+    assert_int_equal(action->type, HCI_AUTO_CHECKPOINT);
+    assert_int_equal(action->write_snapshot, 1);
+    assert_true(manager->LongestTimeBetweenQueries == 1.0);
+}
+
+static void
+test_hci_auto_checkpoint2(void ** state)
+{
+
+    HCIAction action[1];
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    hci_override_now(manager, 1.0);
+    hci_query(manager, action);
+
+    hci_override_now(manager, 3.0);
+    hci_query(manager, action);
+
+    assert_true(manager->LongestTimeBetweenQueries == 2.0);
+    assert_int_equal(action->type, HCI_AUTO_CHECKPOINT);
+    assert_int_equal(action->write_snapshot, 1);
+}
+
+static void
+test_hci_timeout(void ** state)
+{
+    HCIAction action[1];
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    hci_override_now(manager, 4.0);
+    hci_query(manager, action);
+
+    assert_true(manager->LongestTimeBetweenQueries == 4.0);
+
+    hci_override_now(manager, 8.5);
+    hci_query(manager, action);
+    assert_int_equal(action->type, HCI_TIMEOUT);
+    assert_int_equal(action->write_snapshot, 1);
+}
+
+static void
+test_hci_stop(void ** state)
+{
+    HCIAction action[1];
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    touch(prefix, "stop");
+    hci_override_now(manager, 4.0);
+    hci_query(manager, action);
+    assert_false(exists(prefix, "stop"));
+
+    assert_int_equal(action->type, HCI_STOP);
+    assert_int_equal(action->write_snapshot, 1);
+}
+
+static void
+test_hci_checkpoint(void ** state)
+{
+    HCIAction action[1];
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    touch(prefix, "checkpoint");
+    hci_override_now(manager, 4.0);
+    hci_query(manager, action);
+    assert_false(exists(prefix, "checkpoint"));
+
+    assert_int_equal(action->type, HCI_CHECKPOINT);
+    assert_int_equal(action->write_snapshot, 1);
+}
+
+static void
+test_hci_terminate(void ** state)
+{
+    HCIAction action[1];
+    hci_override_now(manager, 0.0);
+    hci_init(manager, prefix, 10.0, 1.0);
+
+    touch(prefix, "terminate");
+    hci_override_now(manager, 4.0);
+    hci_query(manager, action);
+    assert_false(exists(prefix, "terminate"));
+
+    assert_int_equal(action->type, HCI_TERMINATE);
+    assert_int_equal(action->write_snapshot, 0);
+}
+
+static void setup(void ** state)
+{
+    mkdtemp(prefix);
+    message(0, "UsingPrefix : '%s'\n", prefix);
+
+}
+
+static void teardown(void ** state)
+{
+    remove(prefix);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_hci_no_action),
+        cmocka_unit_test(test_hci_auto_checkpoint),
+        cmocka_unit_test(test_hci_auto_checkpoint2),
+        cmocka_unit_test(test_hci_timeout),
+        cmocka_unit_test(test_hci_stop),
+        cmocka_unit_test(test_hci_checkpoint),
+        cmocka_unit_test(test_hci_terminate),
+    };
+    return cmocka_run_group_tests_mpi(tests, setup, teardown);
+}

--- a/tests/test_hci.c
+++ b/tests/test_hci.c
@@ -78,13 +78,13 @@ test_hci_auto_checkpoint2(void ** state)
 {
 
     HCIAction action[1];
-    hci_override_now(manager, 0.0);
+    hci_override_now(manager, 1.0);
     hci_init(manager, prefix, 10.0, 1.0);
 
-    hci_override_now(manager, 1.0);
+    hci_override_now(manager, 2.0);
     hci_query(manager, action);
 
-    hci_override_now(manager, 3.0);
+    hci_override_now(manager, 4.0);
     hci_query(manager, action);
 
     assert_true(manager->LongestTimeBetweenQueries == 2.0);
@@ -96,10 +96,10 @@ static void
 test_hci_timeout(void ** state)
 {
     HCIAction action[1];
-    hci_override_now(manager, 0.0);
+    hci_override_now(manager, 1.0);
     hci_init(manager, prefix, 10.0, 1.0);
 
-    hci_override_now(manager, 4.0);
+    hci_override_now(manager, 5.0);
     hci_query(manager, action);
 
     assert_true(manager->LongestTimeBetweenQueries == 4.0);

--- a/timebinmgr.c
+++ b/timebinmgr.c
@@ -113,27 +113,6 @@ find_current_sync_point(inttime_t ti)
     return NULL;
 }
 
-/*
- * Return a unplanned SyncPoint.
- *
- * The SyncPoint is owned by the routine.
- *
- * The caller shall know ti is actually synced before
- * calling this routine.
- * */
-SyncPoint *
-make_unplanned_sync_point(inttime_t ti)
-{
-    static SyncPoint Unplanned[1];
-
-    Unplanned[0].ti = ti;
-    Unplanned[0].loga = loga_from_ti(ti);
-    /* set default values */
-    Unplanned[0].write_fof = 0;
-    Unplanned[0].write_snapshot = 0;
-    return &Unplanned[0];
-}
-
 /* Each integer time stores in the first 10 bits the snapshot number.
  * Then the rest of the bits are the standard integer timeline,
  * which should be a power-of-two hierarchy. We use this bit trick to speed up

--- a/timestep.c
+++ b/timestep.c
@@ -224,7 +224,7 @@ find_timesteps(int * MinTimeBin)
 
     if(badstepsizecount) {
         message(0, "bad timestep spotted: terminating and saving snapshot.\n");
-        savepositions(999999);
+        dump_snapshot();
         endrun(0, "Ending due to bad timestep");
     }
     walltime_measure("/Timeline");


### PR DESCRIPTION
Updated timeout strategy that's likely more reliable:

1. queries occur on every PM step.
2. measure the longest time duration between two queries == longest
   time spent between two PM steps.
3. If there isn't enough wallclocktime between now and the limit
   to arrive to the next query, then we have a timeout.