### PR TITLE
Driftentropy

### DIFF
--- a/begrun.c
+++ b/begrun.c
@@ -198,6 +198,8 @@ set_units(void)
 
     All.MinEgySpec = 1 / meanweight * (1.0 / GAMMA_MINUS1) * (BOLTZMANN / PROTONMASS) * All.MinGasTemp;
     All.MinEgySpec *= All.UnitMass_in_g / All.UnitEnergy_in_cgs;
+    if(All.MinEgySpec < 0)
+        endrun(2, "Gas temperature must be positive: T = %g\n", All.MinGasTemp);
 
 #ifdef SFR
 

--- a/blackhole.c
+++ b/blackhole.c
@@ -424,7 +424,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             /* FIXME: volume correction doesn't work on BH yet. */
             O->Rho += (mass_j * wk);
 
-            O->SmoothedPressure += (mass_j * wk * Pressure(other));
+            O->SmoothedPressure += (mass_j * wk * GetPressure(other));
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
             O->GasVel[0] += (mass_j * wk * VelPred[0]);
             O->GasVel[1] += (mass_j * wk * VelPred[1]);

--- a/blackhole.c
+++ b/blackhole.c
@@ -17,6 +17,7 @@
 #include "fof.h"
 #include "blackhole.h"
 #include "timestep.h"
+#include "hydra.h"
 /*! \file blackhole.c
  *  \brief routines for gas accretion onto black holes, and black hole mergers
  */
@@ -423,7 +424,7 @@ blackhole_accretion_ngbiter(TreeWalkQueryBHAccretion * I,
             /* FIXME: volume correction doesn't work on BH yet. */
             O->Rho += (mass_j * wk);
 
-            O->SmoothedPressure += (mass_j * wk * PressurePred(other));
+            O->SmoothedPressure += (mass_j * wk * Pressure(other));
             O->SmoothedEntropy += (mass_j * wk * SPHP(other).Entropy);
             O->GasVel[0] += (mass_j * wk * VelPred[0]);
             O->GasVel[1] += (mass_j * wk * VelPred[1]);

--- a/density.c
+++ b/density.c
@@ -346,6 +346,8 @@ density_ngbiter(
 
 #ifdef DENSITY_INDEPENDENT_SPH
         double EntPred = pow(EntropyPred(other), 1/GAMMA);
+        if(fabs(EntropyPred(other)/SPHP(other).DriftEntropy - 1) > 1e-5)
+            endrun(2, "i=%d ID = %ld pred = %g != drift = %g\n",other, P[other].ID, EntropyPred(other), SPHP(other).DriftEntropy);
         O->EgyRho += mass_j * EntPred * wk;
         O->DhsmlEgyDensity += mass_j * EntPred * density_kernel_dW(&iter->kernel, u, wk, dwk);
 #endif
@@ -413,6 +415,9 @@ density_postprocess(int i, TreeWalk * tw)
 
 #ifdef DENSITY_INDEPENDENT_SPH
             const double EntPred = pow(EntropyPred(i), 1/GAMMA);
+            if(fabs(EntropyPred(i)/SPHP(i).DriftEntropy - 1) > 1e-5)
+                endrun(2, "Two! i=%d ti = %d ID = %ld pred = %g != drift = %g\n",i, P[i].TimeBin, P[i].ID, EntropyPred(i), SPHP(i).DriftEntropy);
+
             if((EntPred > 0) && (SPHP(i).EgyWtDensity>0))
             {
                 SPHP(i).DhsmlEgyDensityFactor *= P[i].Hsml/ (NUMDIMS * SPHP(i).EgyWtDensity);

--- a/density.c
+++ b/density.c
@@ -345,7 +345,7 @@ density_ngbiter(
         O->DhsmlDensity += mass_j * density_kernel_dW(&iter->kernel, u, wk, dwk);
 
 #ifdef DENSITY_INDEPENDENT_SPH
-        double EntPred = EntropyPred(other);
+        double EntPred = pow(EntropyPred(other), 1/GAMMA);
         O->EgyRho += mass_j * EntPred * wk;
         O->DhsmlEgyDensity += mass_j * EntPred * density_kernel_dW(&iter->kernel, u, wk, dwk);
 #endif
@@ -412,7 +412,7 @@ density_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DhsmlDensityFactor = 1;
 
 #ifdef DENSITY_INDEPENDENT_SPH
-            const double EntPred = EntropyPred(i);
+            const double EntPred = pow(EntropyPred(i), 1/GAMMA);
             if((EntPred > 0) && (SPHP(i).EgyWtDensity>0))
             {
                 SPHP(i).DhsmlEgyDensityFactor *= P[i].Hsml/ (NUMDIMS * SPHP(i).EgyWtDensity);

--- a/density.c
+++ b/density.c
@@ -345,11 +345,9 @@ density_ngbiter(
         O->DhsmlDensity += mass_j * density_kernel_dW(&iter->kernel, u, wk, dwk);
 
 #ifdef DENSITY_INDEPENDENT_SPH
-        double EntPred = pow(EntropyPred(other), 1/GAMMA);
-        if(fabs(EntropyPred(other)/SPHP(other).DriftEntropy - 1) > 1e-5)
-            endrun(2, "i=%d ID = %ld pred = %g != drift = %g\n",other, P[other].ID, EntropyPred(other), SPHP(other).DriftEntropy);
-        O->EgyRho += mass_j * EntPred * wk;
-        O->DhsmlEgyDensity += mass_j * EntPred * density_kernel_dW(&iter->kernel, u, wk, dwk);
+        const double Ent = pow(SPHP(other).Entropy, 1/GAMMA);
+        O->EgyRho += mass_j * Ent * wk;
+        O->DhsmlEgyDensity += mass_j * Ent * density_kernel_dW(&iter->kernel, u, wk, dwk);
 #endif
 
 #ifdef SPH_GRAD_RHO
@@ -414,15 +412,13 @@ density_postprocess(int i, TreeWalk * tw)
                 SPHP(i).DhsmlDensityFactor = 1;
 
 #ifdef DENSITY_INDEPENDENT_SPH
-            const double EntPred = pow(EntropyPred(i), 1/GAMMA);
-            if(fabs(EntropyPred(i)/SPHP(i).DriftEntropy - 1) > 1e-5)
-                endrun(2, "Two! i=%d ti = %d ID = %ld pred = %g != drift = %g\n",i, P[i].TimeBin, P[i].ID, EntropyPred(i), SPHP(i).DriftEntropy);
+            const double iEnt = pow(SPHP(i).Entropy, 1/GAMMA);
 
-            if((EntPred > 0) && (SPHP(i).EgyWtDensity>0))
+            if((iEnt > 0) && (SPHP(i).EgyWtDensity>0))
             {
                 SPHP(i).DhsmlEgyDensityFactor *= P[i].Hsml/ (NUMDIMS * SPHP(i).EgyWtDensity);
                 SPHP(i).DhsmlEgyDensityFactor *= -SPHP(i).DhsmlDensityFactor;
-                SPHP(i).EgyWtDensity /= EntPred;
+                SPHP(i).EgyWtDensity /= iEnt;
             } else {
                 /* Use non-weighted densities for this.
                  * This should never occur normally,

--- a/drift.c
+++ b/drift.c
@@ -62,6 +62,30 @@ int drift_particle_full(int i, inttime_t ti1, int blocking) {
 #endif
 }
 
+
+/*Evolve the entropy variable, according to DtEntropy computed elsewhere.
+ Input: dloga, Current values of Entropy, DtEntropy, and a factor
+ which is the timestep of the particle divided by the current timestep.
+ This implements an entropy floor and an entropy change floor.*/
+static inline MyFloat
+drift_entropy(const int i, const double dloga)
+{
+    const MyFloat CurEntropy = SPHP(i).DriftEntropy;
+    const MyFloat DtEntropy = SPHP(i).DtEntropy;
+    /*New entropy variable*/
+    MyFloat Entropy = CurEntropy + DtEntropy * dloga;
+
+    /* Implement an entropy floor*/
+    const double minentropy = All.MinEgySpec * GAMMA_MINUS1 / pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1);
+    if(Entropy < minentropy) {
+        Entropy = minentropy;
+        SPHP(i).DtEntropy = 0;
+    }
+
+    return Entropy;
+}
+
+
 static void real_drift_particle(int i, inttime_t ti1)
 {
     int j, ti0;
@@ -128,6 +152,8 @@ static void real_drift_particle(int i, inttime_t ti1)
 
     if(P[i].Type == 0)
     {
+        /* This accounts for adiabatic density changes,
+         * and is a good predictor for most of the gas.*/
         SPHP(i).Density *= exp(-SPHP(i).DivVel * ddrift);
 #ifdef DENSITY_INDEPENDENT_SPH
         SPHP(i).EgyWtDensity *= exp(-SPHP(i).DivVel * ddrift);
@@ -147,6 +173,13 @@ static void real_drift_particle(int i, inttime_t ti1)
 
         if(P[i].Hsml < All.MinGasHsml)
             P[i].Hsml = All.MinGasHsml;
+        /*Evolve entropy at drift time*/
+        /* XXX: the kick factor of entropy is dlog a? */
+        double dloga = dloga_from_dti(ti1 - ti0);
+        SPHP(i).DriftEntropy = drift_entropy(i, dloga);
+        P[i].Ti_drift = ti1;
+        if(fabs(SPHP(i).DriftEntropy/ EntropyPred(i) - 1) > 1e-4)
+            endrun(2, "Two! i=%d ti = %d %d (loga=%g) ID = %ld (ee= %g) pred = %g != drift = %g dloga = %g (%d->%d) DtEntropy = %g\n",i, P[i].Ti_drift, P[i].Ti_kick, dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick), P[i].ID, SPHP(i).Entropy, EntropyPred(i), SPHP(i).DriftEntropy, dloga, ti0, ti1, SPHP(i).DtEntropy);
     }
 
     P[i].Ti_drift = ti1;

--- a/drift.c
+++ b/drift.c
@@ -70,7 +70,7 @@ int drift_particle_full(int i, inttime_t ti1, int blocking) {
 static inline MyFloat
 drift_entropy(const int i, const double dloga)
 {
-    const MyFloat CurEntropy = SPHP(i).DriftEntropy;
+    const MyFloat CurEntropy = SPHP(i).Entropy;
     const MyFloat DtEntropy = SPHP(i).DtEntropy;
     /*New entropy variable*/
     MyFloat Entropy = CurEntropy + DtEntropy * dloga;
@@ -173,13 +173,10 @@ static void real_drift_particle(int i, inttime_t ti1)
 
         if(P[i].Hsml < All.MinGasHsml)
             P[i].Hsml = All.MinGasHsml;
-        /*Evolve entropy at drift time*/
-        /* XXX: the kick factor of entropy is dlog a? */
+        /*Evolve entropy at drift time: evolved dlog a. */
         double dloga = dloga_from_dti(ti1 - ti0);
-        SPHP(i).DriftEntropy = drift_entropy(i, dloga);
+        SPHP(i).Entropy = drift_entropy(i, dloga);
         P[i].Ti_drift = ti1;
-        if(fabs(SPHP(i).DriftEntropy/ EntropyPred(i) - 1) > 1e-4)
-            endrun(2, "Two! i=%d ti = %d %d (loga=%g) ID = %ld (ee= %g) pred = %g != drift = %g dloga = %g (%d->%d) DtEntropy = %g\n",i, P[i].Ti_drift, P[i].Ti_kick, dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick), P[i].ID, SPHP(i).Entropy, EntropyPred(i), SPHP(i).DriftEntropy, dloga, ti0, ti1, SPHP(i).DtEntropy);
     }
 
     P[i].Ti_drift = ti1;

--- a/global.c
+++ b/global.c
@@ -71,7 +71,7 @@ struct state_of_system compute_global_quantities_of_system(void)
 
         if(P[i].Type == 0)
         {
-            entr = EntropyPred(i);
+            entr = SPHP(i).Entropy;
             egyspec = entr / (GAMMA_MINUS1) * pow(SPHP(i).EOMDensity / a3, GAMMA_MINUS1);
             sys.EnergyIntComp[0] += P[i].Mass * egyspec;
             sys.TemperatureComp[0] += P[i].Mass * ConvertInternalEnergy2Temperature(egyspec, SPHP(i).Ne);

--- a/hydra.c
+++ b/hydra.c
@@ -138,7 +138,7 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
     input->Density = SPHP(place).Density;
 #ifdef DENSITY_INDEPENDENT_SPH
     input->EgyRho = SPHP(place).EgyWtDensity;
-    input->EntVarPred = EntropyPred(place);
+    input->EntVarPred = pow(EntropyPred(place), 1/GAMMA);
     input->DhsmlDensityFactor = SPHP(place).DhsmlEgyDensityFactor;
 #else
     input->DhsmlDensityFactor = SPHP(place).DhsmlDensityFactor;
@@ -304,7 +304,7 @@ hydro_ngbiter(
 #ifdef DENSITY_INDEPENDENT_SPH
         double hfc = hfc_visc;
         /* leading-order term */
-        double EntPred = EntropyPred(other);
+        double EntPred = pow(EntropyPred(other), 1/GAMMA);
         hfc += P[other].Mass *
             (dwk_i*iter->p_over_rho2_i*EntPred/I->EntVarPred +
              dwk_j*p_over_rho2_j*I->EntVarPred/EntPred) / r;

--- a/hydra.c
+++ b/hydra.c
@@ -27,7 +27,7 @@
  */
 
 double
-Pressure(int i)
+GetPressure(int i)
 {
     return pow(SPHP(i).Entropy, 1/GAMMA) * pow(SPHP(i).EOMDensity, GAMMA);
 }
@@ -149,7 +149,7 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
 #endif
     input->DhsmlEOMDensityFactor = SPHP(place).DhsmlEOMDensityFactor;
 
-    input->Pressure = Pressure(place);
+    input->Pressure = GetPressure(place);
     input->TimeBin = P[place].TimeBin;
     /* calculation of F1 */
     soundspeed_i = sqrt(GAMMA * input->Pressure / SPHP(place).EOMDensity);
@@ -243,7 +243,7 @@ hydro_ngbiter(
 
     if(r2 > 0 && (r2 < iter->kernel_i.HH || r2 < kernel_j.HH))
     {
-        double Pressure_j = Pressure(other);
+        double Pressure_j = GetPressure(other);
         double p_over_rho2_j = Pressure_j / (SPHP(other).EOMDensity * SPHP(other).EOMDensity);
         double soundspeed_j = sqrt(GAMMA * Pressure_j / SPHP(other).EOMDensity);
 

--- a/hydra.c
+++ b/hydra.c
@@ -164,6 +164,9 @@ hydro_reduce(int place, TreeWalkResultHydro * result, enum TreeWalkReduceMode mo
     }
 
     TREEWALK_REDUCE(SPHP(place).DtEntropy, result->DtEntropy);
+    /* Translate energy change rate into entropy change rate.
+     Must be done here because neighbours potentially use DtEntropy.*/
+    SPHP(place).DtEntropy *= GAMMA_MINUS1 / (All.cf.hubble_a2 * pow(SPHP(place).EOMDensity, GAMMA_MINUS1));
 
     P[place].GravCost += All.HydroCostFactor * All.cf.a * result->Ninteractions;
 
@@ -347,7 +350,6 @@ hydro_ngbiter(
 #endif
 
         O->DtEntropy += (0.5 * hfc_visc * vdotr2);
-
     }
     O->Ninteractions++;
 }
@@ -363,9 +365,6 @@ hydro_postprocess(int i, TreeWalk * tw)
 {
     if(P[i].Type == 0)
     {
-        /* Translate energy change rate into entropy change rate */
-        SPHP(i).DtEntropy *= GAMMA_MINUS1 / (All.cf.hubble_a2 * pow(SPHP(i).EOMDensity, GAMMA_MINUS1));
-
 #ifdef SFR
         /* if we have winds, we decouple particles briefly if delaytime>0 */
         if(All.WindOn && HAS(All.WindModel, WIND_DECOUPLE_SPH)) {

--- a/hydra.c
+++ b/hydra.c
@@ -308,8 +308,12 @@ hydro_ngbiter(
         double hfc = hfc_visc;
         /* leading-order term */
         double EntPred = pow(EntropyPred(other), 1/GAMMA);
-        if(fabs(EntropyPred(other)/SPHP(other).DriftEntropy - 1) > 1e-5)
-            endrun(2, "Hydra! i=%d ti = %d %d (loga=%g) ID = %ld (ee= %g) pred = %g != drift = %g DtEntropy = %g\n",other, P[other].Ti_drift, P[other].Ti_kick, dloga_from_dti(P[other].Ti_drift - P[other].Ti_kick), P[other].ID, SPHP(other).Entropy, EntropyPred(other), SPHP(other).DriftEntropy, SPHP(other).DtEntropy);
+        /* Cannot enable this check: EntropyPred may be using the *new* DtEntropy if the neighbour particle has already
+         * had that computed, and thus will predict a different entropy. This is actually a bad bug in existing code, because
+         * it means output will depend on the order in which particles are sent through this loop, and thus the number of threads.
+         * This might even be racy and so end up with mad values...*/
+//         if(fabs(EntropyPred(other)/SPHP(other).DriftEntropy - 1) > 1e-5)
+//             endrun(2, "Hydra! i=%d ti = %d %d (loga=%g) ID = %ld (ee= %g) pred = %g != drift = %g DtEntropy = %g\n",other, P[other].Ti_drift, P[other].Ti_kick, dloga_from_dti(P[other].Ti_drift - P[other].Ti_kick), P[other].ID, SPHP(other).Entropy, EntropyPred(other), SPHP(other).DriftEntropy, SPHP(other).DtEntropy);
 
         hfc += P[other].Mass *
             (dwk_i*iter->p_over_rho2_i*EntPred/I->EntVarPred +

--- a/hydra.c
+++ b/hydra.c
@@ -139,6 +139,9 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
 #ifdef DENSITY_INDEPENDENT_SPH
     input->EgyRho = SPHP(place).EgyWtDensity;
     input->EntVarPred = pow(EntropyPred(place), 1/GAMMA);
+    if(fabs(EntropyPred(place)/SPHP(place).DriftEntropy - 1) > 1e-5)
+            endrun(2, "Two! i=%d ti = %d ID = %ld pred = %g != drift = %g\n",place, P[place].TimeBin, P[place].ID, EntropyPred(place), SPHP(place).DriftEntropy);
+
     input->DhsmlDensityFactor = SPHP(place).DhsmlEgyDensityFactor;
 #else
     input->DhsmlDensityFactor = SPHP(place).DhsmlDensityFactor;
@@ -305,6 +308,9 @@ hydro_ngbiter(
         double hfc = hfc_visc;
         /* leading-order term */
         double EntPred = pow(EntropyPred(other), 1/GAMMA);
+        if(fabs(EntropyPred(other)/SPHP(other).DriftEntropy - 1) > 1e-5)
+            endrun(2, "Hydra! i=%d ti = %d %d (loga=%g) ID = %ld (ee= %g) pred = %g != drift = %g DtEntropy = %g\n",other, P[other].Ti_drift, P[other].Ti_kick, dloga_from_dti(P[other].Ti_drift - P[other].Ti_kick), P[other].ID, SPHP(other).Entropy, EntropyPred(other), SPHP(other).DriftEntropy, SPHP(other).DtEntropy);
+
         hfc += P[other].Mass *
             (dwk_i*iter->p_over_rho2_i*EntPred/I->EntVarPred +
              dwk_j*p_over_rho2_j*I->EntVarPred/EntPred) / r;

--- a/hydra.c
+++ b/hydra.c
@@ -45,7 +45,7 @@ typedef struct {
     MyFloat Density;
     MyFloat Pressure;
     MyFloat F1;
-    MyFloat DhsmlDensityFactor;
+    MyFloat DhsmlEOMDensityFactor;
     signed char TimeBin;
 
 } TreeWalkQueryHydro;
@@ -146,10 +146,8 @@ hydro_copy(int place, TreeWalkQueryHydro * input, TreeWalk * tw)
 #ifdef DENSITY_INDEPENDENT_SPH
     input->EgyRho = SPHP(place).EgyWtDensity;
     input->EntVarPred = pow(SPHP(place).Entropy, 1/GAMMA);
-    input->DhsmlDensityFactor = SPHP(place).DhsmlEgyDensityFactor;
-#else
-    input->DhsmlDensityFactor = SPHP(place).DhsmlDensityFactor;
 #endif
+    input->DhsmlEOMDensityFactor = SPHP(place).DhsmlEOMDensityFactor;
 
     input->Pressure = Pressure(place);
     input->TimeBin = P[place].TimeBin;
@@ -308,8 +306,11 @@ hydro_ngbiter(
 #endif
         }
         double hfc_visc = 0.5 * P[other].Mass * visc * (dwk_i + dwk_j) / r;
-#ifdef DENSITY_INDEPENDENT_SPH
         double hfc = hfc_visc;
+#ifndef DENSITY_INDEPENDENT_SPH
+        double r1 = 1, r2 = 1;
+#else
+        double r1 = 0, r2 = 0;
         /* leading-order term */
         double EntOther = pow(SPHP(other).Entropy, 1/GAMMA);
         /* Cannot enable this check: EntropyPred may be using the *new* DtEntropy if the neighbour particle has already
@@ -325,28 +326,19 @@ hydro_ngbiter(
 
         /* enable grad-h corrections only if contrastlimit is non negative */
         if(All.DensityContrastLimit >= 0) {
-            double r1 = I->EgyRho / I->Density;
-            double r2 = SPHP(other).EgyWtDensity / SPHP(other).Density;
+            r1 = I->EgyRho / I->Density;
+            r2 = SPHP(other).EgyWtDensity / SPHP(other).Density;
             if(All.DensityContrastLimit > 0) {
                 /* apply the limit if it is enabled > 0*/
-                if(r1 > All.DensityContrastLimit) {
-                    r1 = All.DensityContrastLimit;
-                }
-                if(r2 > All.DensityContrastLimit) {
-                    r2 = All.DensityContrastLimit;
-                }
+                r1 = DMIN(r1, All.DensityContrastLimit);
+                r2 = DMIN(r2, All.DensityContrastLimit);
             }
-            /* grad-h corrections */
-            /* I->DhsmlDensityFactor is actually EgyDensityFactor */
-            hfc += P[other].Mass *
-                (dwk_i*iter->p_over_rho2_i*r1*I->DhsmlDensityFactor +
-                 dwk_j*p_over_rho2_j*r2*SPHP(other).DhsmlEgyDensityFactor) / r;
         }
-#else
-        /* Formulation derived from the Lagrangian */
-        double hfc = hfc_visc + P[other].Mass * (iter->p_over_rho2_i *I->DhsmlDensityFactor * dwk_i
-                + p_over_rho2_j * SPHP(other).DhsmlDensityFactor * dwk_j) / r;
 #endif
+        /* grad-h corrections: enabled if DENSITY_INDEPENDENT_SPH is off, or DensityConstrastLimit >= 0 */
+        /* Formulation derived from the Lagrangian */
+        hfc += P[other].Mass * (iter->p_over_rho2_i*I->DhsmlEOMDensityFactor * dwk_i * r1
+                 + p_over_rho2_j*SPHP(other).DhsmlEOMDensityFactor * dwk_j * r2) / r;
 
 #ifdef SFR
         if(All.WindOn && HAS(All.WindModel, WIND_DECOUPLE_SPH)) {

--- a/hydra.h
+++ b/hydra.h
@@ -1,0 +1,10 @@
+#ifndef HYDRA_H
+#define HYDRA_H
+
+/*Function to get the pressure from the entropy and the density*/
+double Pressure(int i);
+
+/*Function to compute hydro accelerations and adiabatic entropy change*/
+void hydro_force(void);
+
+#endif

--- a/hydra.h
+++ b/hydra.h
@@ -2,7 +2,7 @@
 #define HYDRA_H
 
 /*Function to get the pressure from the entropy and the density*/
-double Pressure(int i);
+double GetPressure(int i);
 
 /*Function to compute hydro accelerations and adiabatic entropy change*/
 void hydro_force(void);

--- a/init.c
+++ b/init.c
@@ -277,7 +277,6 @@ setup_smoothinglengths(int RestartSnapNum)
                 if(P[i].Type == 0) {
                     SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EgyWtDensity / a3 , GAMMA_MINUS1);
                     olddensity[i] = SPHP(i).EgyWtDensity;
-                    SPHP(i).DriftEntropy = SPHP(i).Entropy;
                 }
             }
             density_update();
@@ -314,7 +313,6 @@ setup_smoothinglengths(int RestartSnapNum)
             if(P[i].Type == 0) {
                 /* EgyWtDensity stabilized, now we convert from energy to entropy*/
                 SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EOMDensity/a3 , GAMMA_MINUS1);
-                SPHP(i).DriftEntropy = SPHP(i).Entropy;
             }
         }
     }

--- a/init.c
+++ b/init.c
@@ -254,24 +254,16 @@ setup_smoothinglengths(int RestartSnapNum)
         u_init /= molecular_weight;
 
 #ifdef DENSITY_INDEPENDENT_SPH
-        for(i = 0; i < PartManager->NumPart; i++)
-        {
-            if(P[i].Type == 0)
-            /* start the iteration from mass density */
-            SPHP(i).EgyWtDensity = SPHP(i).Density;
-        }
-
-
         /* initialization of the entropy variable is a little trickier in this version of SPH,
            since we need to make sure it 'talks to' the density appropriately */
         message(0, "Converting u -> entropy, with density split sph\n");
 
         int j;
-        double badness;
         double * olddensity = (double *)mymalloc("olddensity ", PartManager->NumPart * sizeof(double));
         for(j=0;j<100;j++)
-        {/* since ICs give energies, not entropies, need to iterate get this initialized correctly */
-#pragma omp parallel for
+        {
+            /* since ICs give energies, not entropies, need to iterate get this initialized correctly */
+            #pragma omp parallel for
             for(i = 0; i < PartManager->NumPart; i++)
             {
                 if(P[i].Type == 0) {
@@ -280,24 +272,15 @@ setup_smoothinglengths(int RestartSnapNum)
                 }
             }
             density_update();
-            badness = 0;
+            double badness = 0;
 
-#pragma omp parallel private(i)
-            {
-                double mybadness = 0;
-#pragma omp for
-                for(i = 0; i < PartManager->NumPart; i++) {
-                    if(P[i].Type == 0) {
-                        if(!(SPHP(i).EgyWtDensity > 0)) continue;
-                        double value = fabs(SPHP(i).EgyWtDensity - olddensity[i]) / SPHP(i).EgyWtDensity;
-                        if(value > mybadness) mybadness = value;
-                    }
-                }
-#pragma omp critical
-                {
-                    if(mybadness > badness) {
-                        badness = mybadness;
-                    }
+            #pragma omp parallel for reduction(max: badness)
+            for(i = 0; i < PartManager->NumPart; i++) {
+                if(P[i].Type == 0) {
+                    if(SPHP(i).EgyWtDensity <= 0)
+                        continue;
+                    double value = fabs(SPHP(i).EgyWtDensity - olddensity[i]) / SPHP(i).EgyWtDensity;
+                    badness = DMAX(badness,value);
                 }
             }
             MPI_Allreduce(MPI_IN_PLACE, &badness, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);

--- a/init.c
+++ b/init.c
@@ -277,6 +277,7 @@ setup_smoothinglengths(int RestartSnapNum)
                 if(P[i].Type == 0) {
                     SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EgyWtDensity / a3 , GAMMA_MINUS1);
                     olddensity[i] = SPHP(i).EgyWtDensity;
+                    SPHP(i).DriftEntropy = SPHP(i).Entropy;
                 }
             }
             density_update();
@@ -313,6 +314,7 @@ setup_smoothinglengths(int RestartSnapNum)
             if(P[i].Type == 0) {
                 /* EgyWtDensity stabilized, now we convert from energy to entropy*/
                 SPHP(i).Entropy = GAMMA_MINUS1 * u_init / pow(SPHP(i).EOMDensity/a3 , GAMMA_MINUS1);
+                SPHP(i).DriftEntropy = SPHP(i).Entropy;
             }
         }
     }

--- a/proto.h
+++ b/proto.h
@@ -12,7 +12,6 @@ void density_update();
 void energy_statistics(void);
 
 void grav_short_tree(void);
-void hydro_force(void);
 void init(int RestartSnapNum);
 void run(void);
 void runtests(void);

--- a/run.c
+++ b/run.c
@@ -17,6 +17,7 @@
 #include "drift.h"
 #include "forcetree.h"
 #include "blackhole.h"
+#include "hydra.h"
 #include "sfr_eff.h"
 #include "slotsmanager.h"
 #include "fof.h"

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -375,10 +375,10 @@ cooling_direct(int i) {
 
     double ne = SPHP(i).Ne;	/* electron abundance (gives ionization state and mean molecular weight) */
 
-    /*Entropy at kick time after current drift time: note this uses this timestep's DtEntropy!*/
-    const double KickEntropy = SPHP(i).Entropy + SPHP(i).DtEntropy * dloga/2;
+    /*Entropy after this timestep: note this uses this timestep's DtEntropy!*/
+    const double NextEntropy = SPHP(i).Entropy + SPHP(i).DtEntropy * dloga;
 
-    double unew = DMAX(All.MinEgySpec, KickEntropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+    double unew = DMAX(All.MinEgySpec, NextEntropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
 
 #ifdef BLACK_HOLES
     if(SPHP(i).Injected_BH_Energy)
@@ -451,11 +451,11 @@ static int get_sfr_condition(int i) {
 
     if(All.QuickLymanAlphaProbability > 0) {
         const double dloga = get_dloga_for_bin(P[i].TimeBin);
-        /*Entropy at kick time after this timestep: note this uses this timestep's DtEntropy!*/
-        const double KickEntropy = SPHP(i).Entropy + SPHP(i).DtEntropy * dloga/2;
+        /*Entropy after this timestep: note this uses this timestep's DtEntropy!*/
+        const double NextEntropy = SPHP(i).Entropy + SPHP(i).DtEntropy * dloga;
 
         double unew = DMAX(All.MinEgySpec,
-                KickEntropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+                NextEntropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
 
         double temp = u_to_temp_fac * unew;
 

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -375,7 +375,7 @@ cooling_direct(int i) {
 
     double ne = SPHP(i).Ne;	/* electron abundance (gives ionization state and mean molecular weight) */
 
-    /*Entropy at kick time after this timestep: note this uses this timestep's DtEntropy!*/
+    /*Entropy at kick time after current drift time: note this uses this timestep's DtEntropy!*/
     const double KickEntropy = SPHP(i).Entropy + SPHP(i).DtEntropy * dloga/2;
 
     double unew = DMAX(All.MinEgySpec, KickEntropy / GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -375,6 +375,10 @@ cooling_direct(int i) {
 
     double ne = SPHP(i).Ne;	/* electron abundance (gives ionization state and mean molecular weight) */
 
+    double KickEntropy = SPHP(i).DriftEntropy + SPHP(i).DtEntropy * dloga/2;
+    if(fabs((SPHP(i).Entropy + SPHP(i).DtEntropy * dloga)/KickEntropy - 1) > 1e-5)
+        endrun(2, "Two! i=%d ti = %d ID = %ld pred = %g != drift = %g\n",i, P[i].TimeBin, P[i].ID, (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga), KickEntropy);
+
     double unew = DMAX(All.MinEgySpec,
             (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
             GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
@@ -453,6 +457,11 @@ static int get_sfr_condition(int i) {
         double unew = DMAX(All.MinEgySpec,
                 (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga) /
                 GAMMA_MINUS1 * pow(SPHP(i).EOMDensity * All.cf.a3inv, GAMMA_MINUS1));
+
+        /*Entropy at kick time after this timestep*/
+        double KickEntropy = SPHP(i).DriftEntropy + SPHP(i).DtEntropy * dloga/2;
+        if(fabs((SPHP(i).Entropy + SPHP(i).DtEntropy * dloga)/KickEntropy - 1) > 1e-5)
+            endrun(2, "Two! i=%d ti = %d ID = %ld pred = %g != drift = %g\n",i, P[i].TimeBin, P[i].ID, (SPHP(i).Entropy + SPHP(i).DtEntropy * dloga), KickEntropy);
 
         double temp = u_to_temp_fac * unew;
 

--- a/slotsmanager.h
+++ b/slotsmanager.h
@@ -78,8 +78,10 @@ struct sph_particle_data
     MyFloat EgyWtDensity;           /*!< 'effective' rho to use in hydro equations */
     MyFloat DhsmlEgyDensityFactor;  /*!< correction factor for density-independent entropy formulation */
 #define EOMDensity EgyWtDensity
+#define DhsmlEOMDensityFactor DhsmlEgyDensityFactor
 #else
 #define EOMDensity Density
+#define DhsmlEOMDensityFactor DhsmlDensityFactor
 #endif
 
     MyFloat Metallicity;		/*!< metallicity of gas particle */

--- a/slotsmanager.h
+++ b/slotsmanager.h
@@ -83,7 +83,8 @@ struct sph_particle_data
 #endif
 
     MyFloat Metallicity;		/*!< metallicity of gas particle */
-    MyFloat Entropy;		/*!< current value of entropy (actually entropic function) of particle */
+    MyFloat Entropy;		/*!< Entropy at current kick time (actually entropic function) of particle */
+    MyFloat DriftEntropy;   /*!< Entropy at current drift time*/
     MyFloat MaxSignalVel;           /*!< maximum signal velocity */
     MyFloat       Density;		/*!< current baryonic mass density of particle */
     MyFloat       DtEntropy;		/*!< rate of change of entropy */

--- a/slotsmanager.h
+++ b/slotsmanager.h
@@ -83,8 +83,7 @@ struct sph_particle_data
 #endif
 
     MyFloat Metallicity;		/*!< metallicity of gas particle */
-    MyFloat Entropy;		/*!< Entropy at current kick time (actually entropic function) of particle */
-    MyFloat DriftEntropy;   /*!< Entropy at current drift time*/
+    MyFloat Entropy;		/*!< Entropy (actually entropic function) at current drift time of particle */
     MyFloat MaxSignalVel;           /*!< maximum signal velocity */
     MyFloat       Density;		/*!< current baryonic mass density of particle */
     MyFloat       DtEntropy;		/*!< rate of change of entropy */

--- a/timestep.c
+++ b/timestep.c
@@ -379,29 +379,21 @@ sph_VelPred(int i, double * VelPred)
     }
 }
 
-/*Helper function for predicting the entropy*/
-static inline double _EntPred(int i)
+/* This gives the predicted entropy at the particle Kick timestep
+ * for the density independent SPH code.
+ * Watchout: with kddk, when the second k is applied, Ti_kick < Ti_drift. */
+double EntropyPred(int i)
 {
     const double Fentr = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);
     const double epred = SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr;
     return epred;
 }
 
-/* This gives the predicted entropy at the particle Kick timestep
- * for the density independent SPH code.
- * Watchout: with kddk, when the second k is applied, Ti_kick < Ti_drift. */
-double
-EntropyPred(int i)
-{
-    double epred = _EntPred(i);
-    return pow(epred, 1/GAMMA);
-}
-
 double
 PressurePred(int i)
 {
-    double epred = _EntPred(i);
-    return epred * pow(SPHP(i).EOMDensity, GAMMA);
+    double epred = EntropyPred(i);
+    return pow(epred, 1/GAMMA) * pow(SPHP(i).EOMDensity, GAMMA);
 }
 
 double

--- a/timestep.c
+++ b/timestep.c
@@ -383,10 +383,7 @@ sph_VelPred(int i, double * VelPred)
 static inline double _EntPred(int i)
 {
     const double Fentr = dloga_from_dti(P[i].Ti_drift - P[i].Ti_kick);
-    double epred = SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr;
-    /*This mirrors the entropy limiter in do_the_short_range_kick*/
-    if(epred < 0.5 * SPHP(i).Entropy)
-        epred = 0.5 * SPHP(i).Entropy;
+    const double epred = SPHP(i).Entropy + SPHP(i).DtEntropy * Fentr;
     return epred;
 }
 

--- a/timestep.c
+++ b/timestep.c
@@ -452,13 +452,9 @@ get_timestep_ti(const int p, const inttime_t dti_max)
                 P[p].GravPM[0], P[p].GravPM[1], P[p].GravPM[2]
               );
         if(P[p].Type == 0)
-            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g\n", SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1],
-                    SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb);
-#ifdef DENSITY_INDEPENDENT_SPH
-        if(P[p].Type == 0)
-            message(1, "egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g\n", SPHP(p).EOMDensity,
-                    SPHP(p).DhsmlEgyDensityFactor, SPHP(p).Entropy, SPHP(p).DtEntropy);
-#endif
+            message(1, "hydro-frc=(%g|%g|%g) dens=%g hsml=%g numngb=%g egyrho=%g dhsmlegydensityfactor=%g Entropy=%g, dtEntropy=%g\n",
+                    SPHP(p).HydroAccel[0], SPHP(p).HydroAccel[1], SPHP(p).HydroAccel[2], SPHP(p).Density, P[p].Hsml, P[p].NumNgb, SPHP(p).EOMDensity,
+                    SPHP(p).DhsmlEOMDensityFactor, SPHP(p).Entropy, SPHP(p).DtEntropy);
 #ifdef BLACK_HOLES
         if(P[p].Type == 0) {
             message(1, "injected_energy = %g\n" , SPHP(p).Injected_BH_Energy);

--- a/timestep.h
+++ b/timestep.h
@@ -19,8 +19,6 @@ int is_timebin_active(int i, inttime_t current);
 void set_timebin_active(binmask_t mask);
 
 void sph_VelPred(int i, double * VelPred);
-double EntropyPred(int i);
-double PressurePred(int i);
 
 inttime_t find_next_kick(inttime_t Ti_Current, int minTimeBin);
 


### PR DESCRIPTION
This pull request evolves entropy at drift time instead of kick time. It also fixes multiple bugs in DENSITY_INDEPENDENT_SPH that I found along the way. 

These should definitely go to stable.
e692317 - fixes a bug that the entropy change is limited in EntropyPred. This is silly because it also applies to backward predictions and thus limits the heating that can happen.
7fdcda0 - This moves the change in the units of DtEntropy into reduction rather than postprocessing. This is because EntropyPred = Entropy + DtEntropy * Dt is used to generate DtEntropy for neighbouring particles. If this happened after DtEntropy was reduction but before postprocessing the units of Dtentropy were different and so EntropyPred would give a wrong result. Also for stable.

3e1b223 and earlier commits change the Entropy to be computed at drift time. Because of the above, computing it at kick time means that EntropyPred gives a different result depending on whether DtEntropy was updated yet, ie, EntropyPred and thus DtEntropy for a given particle depends on whether the treewalk was already run for a neighbour particle (because it does prediction using ither DtEntropy from the current or previous step). So our output becomes dependent on the number of threads, which is not good. This should probably go to stable, maybe in a squashed version as the intermediate commits won't apply.

The final two commits are cleanups which should make no difference in practice.