### PR TITLE
add -DSTACKTRACE; print stack trace with an external tool.

### DIFF
--- a/Options.mk.example
+++ b/Options.mk.example
@@ -18,7 +18,9 @@ GSL_LIBS = $(shell pkg-config --libs gsl)
 #--------------------------------------- Basic operation mode of code
 OPT += -DDENSITY_INDEPENDENT_SPH
 #OPT += -DLIGHTCONE                       # write a lightcone on the fly; in development
-#OPT += VALGRIND  # allow debugging with valgrind, disable the GADGET memory allocator.
+#OPT += VALGRIND     # allow debugging with valgrind, disable the GADGET memory allocator.
+#OPT += -DDEBUG      # print a lot of debugging messages
+#OPT += -DSTACKTRACE # try to print a better stack trace at endrun and if killed by a signal.
 
 # flags shall that always be there they need to be cleaned up
 OPT += -DOPENMP_USE_SPINLOCK

--- a/endrun.c
+++ b/endrun.c
@@ -1,9 +1,111 @@
 #include <mpi.h>
 #include <stdio.h>
+
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
+#include <errno.h>
 
 #include "endrun.h"
+#ifdef STACKTRACE
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <execinfo.h>
+/* obtain a stacktrace with exec/fork. this is signal handler safe.
+ * function based on xorg_backtrace_pstack;
+ * extracted from  xorg-server/os/backtrace.c
+ * */
+static int
+show_backtrace(void)
+{
+    pid_t kidpid;
+    int pipefd[2];
+
+    if (pipe(pipefd) != 0) {
+        return -1;
+    }
+
+    kidpid = fork();
+
+    if (kidpid == -1) {
+        /* ERROR */
+        return -1;
+    } else if (kidpid == 0) {
+        /* CHILD */
+        char parent[16];
+        char buf[512];
+        seteuid(0);
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+        dup2(pipefd[1],STDOUT_FILENO);
+        dup2(pipefd[1],STDERR_FILENO);
+
+        snprintf(parent, sizeof(parent), "%d", getppid());
+
+        /* try a few tools in order */
+        execle("/usr/bin/pstack", "pstack", parent, NULL, NULL);
+        execle("/usr/bin/eu-stack", "eu-stack", "-p", parent, NULL, NULL);
+
+        sprintf(buf, "No tools to pretty print a stack trace for pid %d.\n"
+                     "Fallback to glibc backtrace which may not contain all symbols.\n "
+                     "run eu-addr2line to pretty print the output.\n", getppid());
+
+        write(STDOUT_FILENO, buf, strlen(buf));
+        exit(EXIT_FAILURE);
+    } else {
+        /* PARENT */
+        char btline[256];
+        int kidstat = 0;
+        int bytesread;
+        int done = 0;
+
+        close(pipefd[1]);
+
+        while (!done) {
+            bytesread = read(pipefd[0], btline, sizeof(btline) - 1);
+
+            if (bytesread > 0) {
+                btline[bytesread] = 0;
+                write(STDOUT_FILENO, btline, strlen(btline));
+            }
+            else if ((bytesread < 0) ||
+                    ((errno != EINTR) && (errno != EAGAIN)))
+                done = 1;
+        }
+        close(pipefd[0]);
+
+        waitpid(kidpid, &kidstat, 0);
+
+        if (WIFEXITED(kidstat) && (WEXITSTATUS(kidstat) == EXIT_FAILURE)) {
+            void * buf[100];
+            backtrace_symbols_fd(buf, 100, STDOUT_FILENO);
+            return -1;
+        }
+    }
+    return 0;
+}
+#else
+static int
+show_backtrace(void)
+{
+    return 0;
+}
+#endif
+
+static void
+OsSigHandler(int no)
+{
+    const char btline[] = "Killed by Signal %d\n";
+    char buf[128];
+    sprintf(buf, btline, no);
+    write(STDOUT_FILENO, buf, strlen(buf));
+
+    show_backtrace();
+    exit(-no);
+}
+
 
 /* Watch out:
  *
@@ -14,6 +116,27 @@
  */
 
 static double _timestart = -1;
+
+void
+init_endrun()
+{
+    _timestart = MPI_Wtime();
+
+#ifdef STACKTRACE
+    struct sigaction act, oact;
+
+    int siglist[] = { SIGSEGV, SIGQUIT, SIGILL, SIGFPE, SIGBUS, 0};
+    sigemptyset(&act.sa_mask);
+
+    act.sa_handler = OsSigHandler;
+    act.sa_flags = 0;
+
+    int i;
+    for(i = 0; siglist[i] != 0; i ++) {
+        sigaction(siglist[i], &act, &oact);
+    }
+#endif
+}
 /*  This function aborts the simulation.
  *
  *  if where > 0, the error is uncollective.
@@ -24,8 +147,6 @@ void endrun(int where, const char * fmt, ...)
 {
     int ThisTask;
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
-    if(_timestart < 0) _timestart = MPI_Wtime();
-
     va_list va;
     char buf[4096];
     va_start(va, fmt);
@@ -34,10 +155,12 @@ void endrun(int where, const char * fmt, ...)
     if(where > 0) {
         printf("[ %09.2f ] Task %d: %s", MPI_Wtime() - _timestart, ThisTask, buf);
         fflush(stdout);
+        show_backtrace();
         MPI_Abort(MPI_COMM_WORLD, where);
     } else {
         if(ThisTask == 0) {
             printf("[ %09.2f ] %s", MPI_Wtime() - _timestart, buf);
+            show_backtrace();
             fflush(stdout);
         }
         MPI_Abort(MPI_COMM_WORLD, where);
@@ -55,7 +178,6 @@ void message(int where, const char * fmt, ...)
     int ThisTask;
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
 
-    if(_timestart < 0) _timestart = MPI_Wtime();
 
     va_list va;
     char buf[4096];

--- a/endrun.c
+++ b/endrun.c
@@ -175,8 +175,8 @@ void endrun(int where, const char * fmt, ...)
     } else {
         if(ThisTask == 0) {
             printf("[ %09.2f ] %s", MPI_Wtime() - _timestart, buf);
-            show_backtrace();
             fflush(stdout);
+            show_backtrace();
         }
         MPI_Abort(MPI_COMM_WORLD, where);
     }

--- a/endrun.h
+++ b/endrun.h
@@ -1,3 +1,5 @@
 
+void init_endrun();
+
 void endrun(int where, const char * fmt, ...);
 void message(int where, const char * fmt, ...);

--- a/genic/main.c
+++ b/genic/main.c
@@ -21,6 +21,7 @@ int main(int argc, char **argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
   MPI_Comm_size(MPI_COMM_WORLD, &NTask);
+  init_endrun();
 
   if(argc < 2)
     endrun(0,"Please pass a parameter file.\n");

--- a/main.c
+++ b/main.c
@@ -34,6 +34,8 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
 
+    init_endrun();
+
     if(argc < 2)
     {
         if(ThisTask == 0)

--- a/tests/stub.c
+++ b/tests/stub.c
@@ -23,6 +23,8 @@ _cmocka_run_group_tests_mpi(const char * name, const struct CMUnitTest tests[], 
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     MPI_Comm_size(MPI_COMM_WORLD, &NTask);
 
+    init_endrun();
+
     if(NTask != 1) {
         setenv("CMOCKA_TEST_ABORT", "1", 1);
     }


### PR DESCRIPTION
When no tools exist it will fallback to glibc's backtrace.

The code is largely modelled from xorg-server's backtrace and osinit.

  