### PR TITLE
Fix growth function in the presence of massive neutrinos

### DIFF
--- a/begrun.c
+++ b/begrun.c
@@ -189,7 +189,7 @@ set_units(void)
     /* convert some physical input parameters to internal units */
 
     All.CP.Hubble = HUBBLE * All.UnitTime_in_s;
-    init_cosmology(&All.CP, All.TimeInit);
+    init_cosmology(&All.CP, All.TimeInit, All.BoxSize * All.UnitLength_in_cm);
     /*Initialise the hybrid neutrinos, after Omega_nu*/
     if(All.HybridNeutrinosOn)
         init_hybrid_nu(&All.CP.ONu.hybnu, All.CP.MNu, All.HybridVcrit, C/1e5, All.HybridNuPartTime, All.CP.ONu.kBtnu);

--- a/cosmology.h
+++ b/cosmology.h
@@ -45,5 +45,5 @@ double GrowthFactor(double astart, double aend);
 double F_Omega(double a);
 
 /*Initialise the derived parts of the cosmology*/
-void init_cosmology(Cosmology *CP, double TimeBegin);
+void init_cosmology(Cosmology *CP, double TimeBegin, double box);
 #endif

--- a/genic/main.c
+++ b/genic/main.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 
   int64_t TotNumPart = (int64_t) Ngrid*Ngrid*Ngrid;
 
-  init_cosmology(&CP, InitTime);
+  init_cosmology(&CP, InitTime, Box * UnitLength_in_cm);
 
   initialize_powerspectrum(ThisTask, InitTime, UnitLength_in_cm, &CP, &PowerP);
   petapm_init(Box, Nmesh, 1);

--- a/tests/test_cosmology.c
+++ b/tests/test_cosmology.c
@@ -39,7 +39,7 @@ void setup_cosmology(Cosmology * CP, double Omega0, double OmegaBaryon, double H
     /*Should be 0.1*/
     CP->Hubble = HUBBLE * UnitTime_in_s;
     /*Do the main cosmology initialisation*/
-    init_cosmology(CP,0.01);
+    init_cosmology(CP,0.01, 1);
 }
 
 static inline double radgrow(double aa, double omegar) {


### PR DESCRIPTION
Neutrinos are usually free-streaming at simulation start over the scales of interest
and so need to be omitted from the source term of the growth function.

We also warn in case the box is large enough that free-streaming is not
a good approximation, which is most of the code.

This fixes a porting bug from S-GenIC and warns in a case where our ICs may be inaccurate at the percent level.