### PR TITLE
Openmpmoments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 
 install:
     - sh bootstrap.sh
-    - cp Options.mk.travis Options.mk
+    - cp platform-options/Options.mk.travis Options.mk
     - make depends
     - make
 

--- a/forcetree.c
+++ b/forcetree.c
@@ -205,6 +205,7 @@ static void init_internal_node(struct NODE *nfreep, struct NODE *parent, int sub
     nfreep->len = 0.5 * parent->len;
     nfreep->f.TopLevel = 0;
     nfreep->f.InternalTopLevel = 0;
+    nfreep->f.MomentsDone = 0;
 
     for(j = 0; j < 3; j++) {
         /* Detect which quadrant we are in by testing the bits of subnode:
@@ -352,6 +353,7 @@ int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
         nfreep->father = -1;
         nfreep->f.TopLevel = 1;
         nfreep->f.InternalTopLevel = 0;
+        nfreep->f.MomentsDone = 0;
         nnext++;
         /* create a set of empty nodes corresponding to the top-level domain
          * grid. We need to generate these nodes first to make sure that we have a
@@ -963,7 +965,7 @@ void force_exchange_pseudodata(void)
         }
     }
 
-    /* share the pseudo-particle data accross CPUs */
+    /* share the pseudo-particle data across CPUs */
 
     recvcounts = (int *) mymalloc("recvcounts", sizeof(int) * NTask);
     recvoffset = (int *) mymalloc("recvoffset", sizeof(int) * NTask);

--- a/forcetree.c
+++ b/forcetree.c
@@ -687,7 +687,7 @@ add_particle_moment_to_node(struct NODE * pnode, int i)
 
 /*Get the sibling of a node, using the suns array. Only to be used in the tree build, before update_node_recursive is called.*/
 static int
-force_get_sibling(int sib, int j, int * suns)
+force_get_sibling(const int sib, const int j, const int * suns)
 {
     /* check if we have a sibling on the same level */
     int jj;
@@ -752,7 +752,7 @@ force_update_node_recursive(int no, int sib, int level, const struct TreeBuilder
              *or if we are deep enough that we already spawned a lot.
              Note: final clause is much slower for some reason. */
             if(chldcnt > 1 && level < 513) {
-                #pragma omp task shared(tails)
+                #pragma omp task default(none) shared(tails, level, chldcnt) firstprivate(j, nextsib, p)
                 tails[j] = force_update_node_recursive(p, nextsib, level*chldcnt, tb);
             }
             else

--- a/forcetree.c
+++ b/forcetree.c
@@ -912,24 +912,14 @@ force_update_node_parallel(const struct TreeBuilder tb)
 
     int nfound = 0;
 
-    /*The loop is only necessary for slightly pathological cases. Probably not worth it.*/
-    while(nfound < ntasks/8) {
-        nfound = 0;
-        #pragma omp parallel for
-        for(i=0; i<ntasks;i++)
-            TaskNodes[i].node = -1;
+    #pragma omp parallel for
+    for(i=0; i<ntasks;i++)
+        TaskNodes[i].node = -1;
 
-        /*Only refine local leaf nodes*/
-        for(i = Tasks[ThisTask].StartLeaf; i < Tasks[ThisTask].EndLeaf; i ++) {
-            int no = TopLeaves[i].treenode;
-            force_queue_refinement(no, levels-1, &nfound, TaskNodes, ntasks, &tb);
-        }
-        /*In case we did not get enough nodes, refine again*/
-        levels+=1;
-        message(1,"ntasks = %d empty = %d levels = %d\n", ntasks, ntasks - nfound, levels);
-        /*Enforce sanity: make sure 8^levels < 2^32.*/
-        if(levels > 10)
-            break;
+    /*Only refine local leaf nodes*/
+    for(i = Tasks[ThisTask].StartLeaf; i < Tasks[ThisTask].EndLeaf; i ++) {
+        int no = TopLeaves[i].treenode;
+        force_queue_refinement(no, levels-1, &nfound, TaskNodes, ntasks, &tb);
     }
 
     /*Sort these nodes*/

--- a/forcetree.c
+++ b/forcetree.c
@@ -720,11 +720,6 @@ force_update_node_recursive(int no, int sib, int level, const struct TreeBuilder
     /*Last value of tails is the return value of this function*/
     int j, suns[8], tails[8];
 
-    /* Only start spawning new tasks when we are past the top level nodes,
-     * to prevent us being overwhelmed by very short tasks pointing to pseudoparticles*/
-    if(level < 0 && Nodes[no].f.TopLevel && !Nodes[no].f.InternalTopLevel)
-        level = 1;
-
     /*Count how many internal children we have,
      *so we can keep track of how many tasks we started*/
     int chldcnt=0;
@@ -758,7 +753,7 @@ force_update_node_recursive(int no, int sib, int level, const struct TreeBuilder
             /*Don't spawn a new task if we only have one child,
              *or if we are deep enough that we already spawned a lot.
              Note: final clause is much slower for some reason. */
-            if(chldcnt > 1 && level >= 0 && level < 513) {
+            if(chldcnt > 1 && level < 513) {
                 #pragma omp task shared(tails)
                 tails[j] = force_update_node_recursive(p, nextsib, level*chldcnt, tb);
             }
@@ -873,7 +868,7 @@ force_update_node_parallel(const struct TreeBuilder tb)
 #pragma omp parallel
 #pragma omp single nowait
     {
-        tail = force_update_node_recursive(tb.firstnode, -1, -1, tb);
+        tail = force_update_node_recursive(tb.firstnode, -1, 1, tb);
     }
     return tail;
 }

--- a/forcetree.c
+++ b/forcetree.c
@@ -205,7 +205,6 @@ static void init_internal_node(struct NODE *nfreep, struct NODE *parent, int sub
     nfreep->len = 0.5 * parent->len;
     nfreep->f.TopLevel = 0;
     nfreep->f.InternalTopLevel = 0;
-    nfreep->f.MomentsDone = 0;
 
     for(j = 0; j < 3; j++) {
         /* Detect which quadrant we are in by testing the bits of subnode:
@@ -353,7 +352,6 @@ int force_tree_create_nodes(const struct TreeBuilder tb, const int npart)
         nfreep->father = -1;
         nfreep->f.TopLevel = 1;
         nfreep->f.InternalTopLevel = 0;
-        nfreep->f.MomentsDone = 0;
         nnext++;
         /* create a set of empty nodes corresponding to the top-level domain
          * grid. We need to generate these nodes first to make sure that we have a

--- a/forcetree.c
+++ b/forcetree.c
@@ -936,13 +936,15 @@ force_update_node_parallel(const struct TreeBuilder tb)
     qsort_openmp(TaskNodes, nfound, sizeof(struct TaskNode), compare_nodes);
 
     /* now compute the multipole moments recursively for each subtree*/
-    #pragma omp parallel for schedule(dynamic,1)
-    for(i = nfound-1; i >= 0; i--)
-    {
-        if(TaskNodes[i].node >= tb.lastnode || TaskNodes[i].node < tb.firstnode)
-            endrun(1,"Received bad task node (should not happen): no = %d i = %d\n",TaskNodes[i].node, i);
-        TaskNodes[i].tail = force_update_node_recursive(TaskNodes[i].node, TaskNodes[i].sibling, -1, NULL, 0, &tb);
-        tb.Nodes[TaskNodes[i].node].f.MomentsDone = 1;
+    if(nfound > 0) {
+        #pragma omp parallel for schedule(dynamic,1)
+        for(i = nfound-1; i >= 0; i--)
+        {
+            if(TaskNodes[i].node >= tb.lastnode || TaskNodes[i].node < tb.firstnode)
+                endrun(1,"Received bad task node (should not happen): no = %d i = %d\n",TaskNodes[i].node, i);
+             TaskNodes[i].tail = force_update_node_recursive(TaskNodes[i].node, TaskNodes[i].sibling, -1, NULL, 0, &tb);
+             tb.Nodes[TaskNodes[i].node].f.MomentsDone = 1;
+         }
     }
 
     /*Now do the final stage in serial*/

--- a/forcetree.h
+++ b/forcetree.h
@@ -19,7 +19,6 @@ extern struct NODE
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
         unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
-        unsigned int MomentsDone:1;            /*True if we computed the moments already. Used in tree build*/
     } f;
     union
     {

--- a/forcetree.h
+++ b/forcetree.h
@@ -19,6 +19,7 @@ extern struct NODE
         unsigned int TopLevel :1; /* Node corresponding to a toplevel node */
         unsigned int DependsOnLocalMass :1;  /* Intersects with local mass */
         unsigned int MixedSofteningsInNode:1;  /* Softening is mixed, need to open the node */
+        unsigned int MomentsDone:1;            /*True if we computed the moments already. Used in tree build*/
     } f;
     union
     {

--- a/genic/main.c
+++ b/genic/main.c
@@ -73,10 +73,10 @@ int main(int argc, char **argv)
   saveheader(&bf, TotNumPart, TotNu, total_nufrac);
   /*Use 'total' (CDM + baryon) transfer function
    * unless DifferentTransferFunctions are on.
-   * Note that massive neutrinos, if present,
-   * will be followed elsewhere.*/
-  int DMType = 2, GasType = 2;
+   */
+  int DMType = 3, GasType = 3, NuType = 3;
   if(ProduceGas && DifferentTransferFunctions) {
+      NuType = 2;
       DMType = 1;
       GasType = 0;
   }
@@ -97,6 +97,7 @@ int main(int argc, char **argv)
   if(NGridNu > 0) {
       int i;
       setup_grid(shift_nu, TotNu);
+      displacement_fields(NuType);
       for(i = 0; i < TotNu; i++)
           add_thermal_speeds(P[i].Vel);
       write_particle_data(2,&bf);

--- a/genic/power.c
+++ b/genic/power.c
@@ -88,8 +88,11 @@ void parse_transfer(int i, double k, char * line, struct table *out_tab, int * I
         transfers[j] = atof(retval);
     }
     /*Order of the transfer table matches the particle types:
-     * 0 is baryons, 1 is CDM, 2 is CMB + baryons.
-     * Everything is a ratio against tot*/
+     * 0 is baryons, 1 is CDM, 2 is CMB + baryons, 3 is massive neutrinos.
+     * Everything is a ratio against tot.
+     * In the input CAMB file 0 is CDM, 1 is baryons, 2 is photons,
+     * 3 is massless neutrinos, 4 is massive neutrinos, 5 is total,
+     * 6 is cdm + baryons.*/
     out_tab->logD[0][i] = pow(transfers[1]/transfers[5],2);
     out_tab->logD[1][i] = pow(transfers[0]/transfers[5],2);
     out_tab->logD[2][i] = pow(transfers[4]/transfers[5],2);

--- a/genic/power.c
+++ b/genic/power.c
@@ -22,7 +22,7 @@ static double PrimordialIndex;
 static double UnitLength_in_cm;
 static Cosmology * CP;
 
-#define MAXCOLS 3
+#define MAXCOLS 4
 
 struct table
 {
@@ -92,7 +92,8 @@ void parse_transfer(int i, double k, char * line, struct table *out_tab, int * I
      * Everything is a ratio against tot*/
     out_tab->logD[0][i] = pow(transfers[1]/transfers[5],2);
     out_tab->logD[1][i] = pow(transfers[0]/transfers[5],2);
-    out_tab->logD[2][i] = pow(transfers[6]/transfers[5],2);
+    out_tab->logD[2][i] = pow(transfers[4]/transfers[5],2);
+    out_tab->logD[3][i] = pow(transfers[6]/transfers[5],2);
 }
 
 void read_power_table(int ThisTask, const char * inputfile, const int ncols, struct table * out_tab, double scale, void (*parse_line)(int i, double k, char * line, struct table *, int *InputInLog10, double scale))

--- a/genic/proto.h
+++ b/genic/proto.h
@@ -6,7 +6,7 @@ void   displacement_fields(int Type);
 void   setup_grid(double shift, int64_t FirstID);
 void   free_ffts(void);
 
-void saveheader(BigFile * bf, int64_t TotNumPart);
+void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);
 void  write_particle_data(int Type, BigFile * bf);
 
 void  read_parameterfile(char *fname);

--- a/genic/save.c
+++ b/genic/save.c
@@ -58,13 +58,14 @@ void write_particle_data(int Type, BigFile * bf) {
     walltime_measure("/Write");
 }
 
-void saveheader(BigFile * bf, int64_t TotNumPart) {
+void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac) {
     BigBlock bheader;
     if(0 != big_file_mpi_create_block(bf, &bheader, "Header", NULL, 0, 0, 0, MPI_COMM_WORLD)) {
         endrun(0, "failed to create block %s:%s", "Header",
                 big_file_get_error_message());
     }
 
+    const double OmegatoMass = 3 * CP.Hubble * CP.Hubble / (8 * M_PI * G) * pow(Box, 3);
     int64_t totnumpart[6] = {0};
     double mass[6] = {0};
     totnumpart[1] = TotNumPart;
@@ -74,9 +75,15 @@ void saveheader(BigFile * bf, int64_t TotNumPart) {
         mass[0] = (CP.OmegaBaryon) * 3 * CP.Hubble * CP.Hubble / (8 * M_PI * G) * pow(Box, 3) / TotNumPart;
         OmegaCDM -= CP.OmegaBaryon;
     }
-    if(CP.MNu[0] + CP.MNu[1] + CP.MNu[2] > 0)
-        OmegaCDM -= get_omega_nu(&CP.ONu, 1);
-    mass[1] = OmegaCDM * 3 * CP.Hubble * CP.Hubble / (8 * M_PI * G) * pow(Box, 3) / TotNumPart;
+    if(CP.MNu[0] + CP.MNu[1] + CP.MNu[2] > 0) {
+        double OmegaNu = get_omega_nu(&CP.ONu, 1);
+        OmegaCDM -= OmegaNu;
+        if(TotNuPart > 0) {
+            totnumpart[2] = TotNuPart;
+            mass[2] = nufrac * OmegaNu * OmegatoMass / totnumpart[2];
+        }
+    }
+    mass[1] = OmegaCDM * OmegatoMass / TotNumPart;
     double redshift = 1.0 / InitTime - 1.;
 
     int rt =(0 != big_block_set_attr(&bheader, "TotNumPart", totnumpart, "i8", 6)) ||

--- a/genic/save.c
+++ b/genic/save.c
@@ -93,6 +93,7 @@ void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufr
             (big_block_set_attr(&bheader, "BoxSize", &Box, "f8", 1)) ||
             (big_block_set_attr(&bheader, "UsePeculiarVelocity", &UsePeculiarVelocity, "i4", 1)) ||
             (big_block_set_attr(&bheader, "Omega0", &CP.Omega0, "f8", 1)) ||
+            (big_block_set_attr(&bheader, "FractionNuInParticles", &nufrac, "f8", 1)) ||
             (big_block_set_attr(&bheader, "OmegaBaryon", &CP.OmegaBaryon, "f8", 1)) ||
             (big_block_set_attr(&bheader, "OmegaLambda", &CP.OmegaLambda, "f8", 1)) ||
             (big_block_set_attr(&bheader, "UnitLength_in_cm", &UnitLength_in_cm, "f8", 1)) ||

--- a/sfr_eff.c
+++ b/sfr_eff.c
@@ -35,6 +35,16 @@
 /*Cooling only: no star formation*/
 static void cooling_direct(int i);
 
+/*
+ * This routine does cooling and star formation for
+ * the effective multi-phase model.
+ */
+static int
+sfr_cooling_haswork(int target, TreeWalk * tw)
+{
+    return P[target].Type == 0 && P[target].Mass > 0;
+}
+
 #ifdef SFR
 static double u_to_temp_fac; /* assuming very hot !*/
 
@@ -56,16 +66,6 @@ static double get_sfr_factor_due_to_selfgravity(int i);
 static double get_sfr_factor_due_to_h2(int i);
 static double get_starformation_rate_full(int i, double dtime, MyFloat * ne_new, double * trelax, double * egyeff);
 static double find_star_mass(int i);
-
-/*
- * This routine does cooling and star formation for
- * the effective multi-phase model.
- */
-static int
-sfr_cooling_haswork(int target, TreeWalk * tw)
-{
-    return P[target].Type == 0 && P[target].Mass > 0;
-}
 
 /*Prototypes and structures for the wind model*/
 typedef struct {

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -24,7 +24,7 @@ struct TreeBuilder
 force_treeallocate(int maxnodes, int maxpart, int first_node_offset);
 
 int
-force_update_node_recursive(int no, int sib, int tail, const struct TreeBuilder tb);
+force_update_node_parallel(const struct TreeBuilder tb);
 
 /*Used data from All and domain*/
 struct part_manager_type PartManager[1] = {{0}};
@@ -266,7 +266,7 @@ static void do_tree_test(const int numpart, const struct TreeBuilder tb)
     int nrealnode = check_tree(tb, nodes, numpart);
     /* now compute the multipole moments recursively */
     start = MPI_Wtime();
-    int tail = force_update_node_recursive(numpart, -1, -1, tb);
+    int tail = force_update_node_parallel(tb);
     force_set_next_node(tail, -1, tb);
 /*     assert_true(tail < nodes); */
     end = MPI_Wtime();
@@ -374,6 +374,7 @@ static int setup_tree(void **state) {
     /*Set up the important parts of the All structure.*/
     /*Particles should not be outside this*/
     All.BoxSize = 8;
+    All.NumThreads = omp_get_max_threads();
     int i;
     for(i=0; i<6; i++)
         GravitySofteningTable[i] = 0.1 / 2.8;

--- a/tests/test_forcetree.c
+++ b/tests/test_forcetree.c
@@ -109,6 +109,7 @@ static int check_moments(const struct TreeBuilder tb, const int numpart, const i
     }
     int node = tb.firstnode;
     int counter = 0;
+    int sibcntr = 0;
     while(node >= 0) {
         assert_true(node >= -1 && node < tb.lastnode);
         int next = force_get_next_node(node,tb);
@@ -132,6 +133,9 @@ static int check_moments(const struct TreeBuilder tb, const int numpart, const i
                 assert_int_equal(ances, sfather);
 /*                 printf("node %d ances %d sib %d next %d father %d sfather %d\n",node, ances, sib, force_get_next_node(node, tb), father, sfather); */
             }
+            else if(sib == -1)
+                sibcntr++;
+
             if(!(Nodes[node].u.d.mass < 0.5 && Nodes[node].u.d.mass > -0.5)) {
                 printf("node %d (%d) mass %g / %g TL %d DLM %d MS %g MSN %d ITL %d\n", 
                     node, node - tb.firstnode, Nodes[node].u.d.mass, oldmass[node - tb.firstnode],
@@ -156,6 +160,7 @@ static int check_moments(const struct TreeBuilder tb, const int numpart, const i
         node = next;
     }
     assert_int_equal(counter, nrealnode);
+    assert(sibcntr < counter/100);
 
     free(oldmass);
     return nrealnode;


### PR DESCRIPTION
Thread the second phase of the tree build procedure, the moments calculation. This is done using a split/merge algorithm. It doesn't work particularly well with the treebuild test (because those are deliberately pathological setups) , but it scales roughly linearly with thread number up to at least 8 threads on a real simulation.

Testing done:
- dm-only example to z=3 with 8 threads and 4 mpis / 2 threads (on a hyperthreaded quad-core), and I checked the final output was the same for master and this branch in both cases. Note that the output did differ slightly between the 8 threads and 4 mpis/2 threads tests, which may need investigating.

With this the % time spent in tree build goes from 11% in the 8 thread example to 6%.