### PR TITLE
Add two useful python scripts

### DIFF
--- a/genic/main.c
+++ b/genic/main.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
       int i;
       setup_grid(shift_nu, TotNu);
       displacement_fields(NuType);
-      for(i = 0; i < TotNu; i++)
+      for(i = 0; i < NumPart; i++)
           add_thermal_speeds(P[i].Vel);
       write_particle_data(2,&bf);
       free_ffts();

--- a/hci.c
+++ b/hci.c
@@ -166,7 +166,7 @@ hci_query(HCIManager * manager, HCIAction * action)
     /* Will we run out of time by the query ? highest priority.
      */
     if(hci_query_timeout(manager, &request)) {
-        message(0, "HCI: Stopping due to TimeLimitCPU, dumping a CheckPoint\n.");
+        message(0, "HCI: Stopping due to TimeLimitCPU, dumping a CheckPoint.\n");
         action->type = HCI_TIMEOUT;
         action->write_snapshot = 1;
         free(request);

--- a/tools/compare_snap.py
+++ b/tools/compare_snap.py
@@ -1,0 +1,35 @@
+"""This module compares two snapshots to ensure they are the same.
+The main purpose is for development, to make sure that optimizations do not change
+the code output."""
+
+import bigfile
+import numpy as np
+
+def compare_fields(newsnap, oldsnap, ptype=1, field="Position"):
+    """Compare two fields in a snapshot (by default DM positions):
+       newsnap and oldsnap are compared.
+       the 'field' array is compared for particle type 'ptype'.
+       Returns the absolute value of the differences."""
+    pp_old = bigfile.BigFile(oldsnap)
+    box = pp_old["Header"].attrs["BoxSize"]
+    otime = pp_old["Header"].attrs["Time"]
+    pp_new = bigfile.BigFile(newsnap)
+    ntime = pp_new["Header"].attrs["Time"]
+    nbox = pp_new["Header"].attrs["BoxSize"]
+    assert np.abs(otime - ntime) < 1e-8
+    assert np.abs(box - nbox) < 1e-8
+    sptype = str(ptype)
+    id_new = pp_new[sptype+"/ID"][:]
+    id_old = pp_old[sptype+"/ID"][:]
+    pos_new = pp_new[sptype+"/"+field][:]
+    pos_old = pp_old[sptype+"/"+field][:]
+    p_sort_new = pos_new[np.argsort(id_new)]
+    p_sort_old = pos_old[np.argsort(id_old)]
+    diff = p_sort_new - p_sort_old
+    #Positions wrap, so the differences
+    if field == "Position":
+        ii = np.where(diff > box/2)
+        diff[ii] = diff[ii] - box
+        ii = np.where(diff < -box/2)
+        diff[ii] = diff[ii] + box
+    return np.abs(diff)

--- a/tools/hmffromfof.py
+++ b/tools/hmffromfof.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""This module prints a halo mass function from MP-Gadget's built in FOF tables.
+        halo_mass_function: returns dn/dM in M_sun/Mpc^3
+"""
+
+from __future__ import division,print_function
+import numpy as np
+import bigfile
+
+
+def HMFFromFOF(foftable, h0=False, bins='auto'):
+    """Print a conventionally normalised halo mass function from the FOF tables.
+    Units returned are:
+    dn/dM (M_sun/Mpc^3) (comoving) Note no little-h!
+    If h0 == True, units are dn/dM (h^4 M_sun/Mpc^3)
+    bins specifies the number of evenly spaced bins if an integer,
+    or one of the strings understood by numpy.histogram."""
+    bf = bigfile.BigFile(foftable)
+    #1 solar in g
+    msun_in_g = 1.989e33
+    #1 Mpc in cm
+    Mpc_in_cm = 3.085678e+24
+    #In units of 10^10 M_sun by default.
+    try:
+        imass_in_g = bf["Header"].attrs["UnitMass_in_g"]
+    except KeyError:
+        imass_in_g = 1.989e43
+    #Length in units of kpc/h by default
+    try:
+        ilength_in_cm = bf["Header"].attrs["UnitLength_in_cm"]
+    except KeyError:
+        ilength_in_cm = 3.085678e+21
+    hub = bf["Header"].attrs["HubbleParam"]
+    box = bf["Header"].attrs["BoxSize"]
+    #Convert to Mpc from kpc/h:
+    box *= ilength_in_cm / hub / Mpc_in_cm
+    masses = bf["FOFGroups/Mass"][:]
+    #This is N(M) evenly spaced in log(M)
+    NM, Mbins = np.histogram(np.log10(masses), bins=bins)
+    #Convert Mbins to Msun
+    Mbins = 10**Mbins
+    Mbins *= (imass_in_g / msun_in_g)
+    #Find dM:
+    #This is dn/dM (Msun)
+    dndm = NM/(Mbins[1:] - Mbins[:-1])
+    Mcent = (Mbins[1:] + Mbins[:-1])/2.
+    #Now divide by the volume:
+    dndm /= box**3
+    if h0:
+        dndm /= hub**4
+    return Mcent, dndm


### PR DESCRIPTION
- compare_snap.py checks whether a field has changed between snapshots (I use it all the time for development).
- hmffromfof uses the FOF output to generate a conventionally unitted halo mass function.
In future we could use it for an integration test that checks we have a
theoretically expected halo mass function.