### PR TITLE
Bring back WDM thermal velocities

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -25,6 +25,7 @@ TESTED = \
 	memory \
 	openmpsort \
 	genic-power \
+	genic-thermal \
 	exchange
 
 MPI_TESTED = exchange

--- a/allvars.h
+++ b/allvars.h
@@ -409,6 +409,7 @@ extern struct global_data_all_processes
     double TimeNextSeedingCheck;  /*Time for the next seed check.*/
     double TimeBetweenSeedingSearch; /*Factor to multiply TimeInit by to find the next seeding check.*/
 
+    int RandomSeed; /*Initial seed for the random number table*/
 }
 All;
 

--- a/begrun.c
+++ b/begrun.c
@@ -82,7 +82,7 @@ void begrun(int RestartSnapNum)
 
     long_range_init();
 
-    set_random_numbers();
+    set_random_numbers(All.RandomSeed);
 
     init(RestartSnapNum);			/* ... read in initial model */
 

--- a/genic/allvars.c
+++ b/genic/allvars.c
@@ -14,6 +14,7 @@ int InvertPhase;
 double MaxMemSizePerNode;
 int DifferentTransferFunctions;
 double Max_nuvel;
+double WDM_therm_mass;
 
 struct part_data *P;
 

--- a/genic/allvars.h
+++ b/genic/allvars.h
@@ -30,6 +30,7 @@ extern struct part_data
 
 extern double InitTime;
 extern double Max_nuvel;
+extern double WDM_therm_mass;
 
 extern char * OutputDir, * FileBase;
 extern int  NumFiles;

--- a/genic/main.c
+++ b/genic/main.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
       shift_nu = -0.5 * (CP.Omega0 - OmegaNu) / CP.Omega0 * meanspacing;
       shift_dm = 0.5 * OmegaNu / CP.Omega0 * meanspacing;
   }
-  setup_grid(ProduceGas * shift_dm, 0);
+  setup_grid(ProduceGas * shift_dm, 0, Ngrid);
 
   /*Write the header*/
   char buf[4096];
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
 
   /*Now make the gas if required*/
   if(ProduceGas) {
-    setup_grid(shift_gas, TotNumPart);
+    setup_grid(shift_gas, TotNumPart, Ngrid);
     displacement_fields(GasType);
     write_particle_data(0, &bf);
     free_ffts();
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
   /*Now add random velocity neutrino particles*/
   if(NGridNu > 0) {
       int i;
-      setup_grid(shift_nu, 2*TotNumPart);
+      setup_grid(shift_nu, 2*TotNumPart, NGridNu);
       displacement_fields(NuType);
       for(i = 0; i < NumPart; i++)
           add_thermal_speeds(&nu_therm, P[i].ID, P[i].Vel);

--- a/genic/main.c
+++ b/genic/main.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
       struct thermalvel WDM;
       init_thermalvel(&WDM, v_th, 10000/v_th, 0);
       for(i = 0; i < NumPart; i++)
-          add_thermal_speeds(&WDM, P[i].Vel);
+          add_thermal_speeds(&WDM, P[i].ID, P[i].Vel);
   }
 
   /*Now make the gas if required*/
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
       setup_grid(shift_nu, TotNu);
       displacement_fields(NuType);
       for(i = 0; i < NumPart; i++)
-          add_thermal_speeds(&nu_therm, P[i].Vel);
+          add_thermal_speeds(&nu_therm, P[i].ID, P[i].Vel);
       write_particle_data(2,&bf);
       free_ffts();
   }

--- a/genic/main.c
+++ b/genic/main.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
   /*Now add random velocity neutrino particles*/
   if(NGridNu > 0) {
       int i;
-      setup_grid(shift_nu, TotNu);
+      setup_grid(shift_nu, 2*TotNumPart);
       displacement_fields(NuType);
       for(i = 0; i < NumPart; i++)
           add_thermal_speeds(&nu_therm, P[i].ID, P[i].Vel);

--- a/genic/params.c
+++ b/genic/params.c
@@ -42,6 +42,7 @@ create_parameters()
     param_declare_double(ps, "MNue", OPTIONAL, 0, "First neutrino mass in eV.");
     param_declare_double(ps, "MNum", OPTIONAL, 0, "Second neutrino mass in eV.");
     param_declare_double(ps, "MNut", OPTIONAL, 0, "Third neutrino mass in eV.");
+    param_declare_double(ps, "MWDM_therm", OPTIONAL, 0, "Assign a thermal velocity to the DM. Specifies WDM particle mass in keV.");
     param_declare_double(ps, "Max_nuvel", OPTIONAL, 5000, "Maximum neutrino velocity sampled from the F-D distribution.");
 
     param_declare_int(ps, "DifferentTransferFunctions", OPTIONAL, 0, "Use species specific transfer functions for baryon and CDM.");
@@ -100,6 +101,7 @@ void read_parameterfile(char *fname)
     CP.MNu[0] = param_get_double(ps, "MNue");
     CP.MNu[1] = param_get_double(ps, "MNum");
     CP.MNu[2] = param_get_double(ps, "MNut");
+    WDM_therm_mass = param_get_double(ps, "MWDM_therm");
     MaxMemSizePerNode = param_get_double(ps, "MaxMemSizePerNode");
     ProduceGas = param_get_int(ps, "ProduceGas");
     /*Unit system*/

--- a/genic/proto.h
+++ b/genic/proto.h
@@ -1,9 +1,10 @@
 #ifndef GENIC_PROTO_H
 #define GENIC_PROTO_H
 #include <bigfile.h>
+#include <stdint.h>
 
 void   displacement_fields(int Type);
-void   setup_grid(double shift, int64_t FirstID);
+void setup_grid(double shift, int64_t FirstID);
 void   free_ffts(void);
 
 void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);

--- a/genic/proto.h
+++ b/genic/proto.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 void   displacement_fields(int Type);
-void setup_grid(double shift, int64_t FirstID);
+void setup_grid(double shift, int64_t FirstID, int Ngrid);
 void   free_ffts(void);
 
 void saveheader(BigFile * bf, int64_t TotNumPart, int64_t TotNuPart, double nufrac);

--- a/genic/thermal.c
+++ b/genic/thermal.c
@@ -7,19 +7,8 @@
 #include <assert.h>
 #include "../endrun.h"
 
-/*Length of the table*/
-#define MAX_FERMI_DIRAC          17.0
-#define LENGTH_FERMI_DIRAC_TABLE 2000
 /*The Boltzmann constant in units of eV/K*/
 #define BOLEVK 8.61734e-5
-
-static double fermi_dirac_vel[LENGTH_FERMI_DIRAC_TABLE];
-static double fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE];
-
-static double m_vamp;
-static gsl_rng * g_rng;
-static gsl_interp * fd_intp;
-static gsl_interp_accel * fd_intp_acc;
 
 /* This function converts the dimensionless units used in the integral to dimensionful units.
  * Unit scaling velocity for neutrinos:
@@ -37,6 +26,15 @@ NU_V0(const double Time, const double kBTNubyMNu, const double UnitVelocity_in_c
     return kBTNubyMNu / Time * (C / UnitVelocity_in_cm_per_s);
 }
 
+//Amplitude of the random velocity for WDM
+double WDM_V0(const double Time, const double WDM_therm_mass, const double Omega_CDM, const double HubbleParam, const double UnitVelocity_in_cm_per_s)
+{
+        //Not actually sure where this equation comes from: the fiducial values are from Bode, Ostriker & Turok 2001.
+        double WDM_V0 = 0.012 / Time * pow(Omega_CDM / 0.3, 1.0 / 3) * pow(HubbleParam / 0.65, 2.0 / 3) * pow(1.0 /WDM_therm_mass,4.0 / 3);
+        WDM_V0 *= 1.0e5 / UnitVelocity_in_cm_per_s;
+        return WDM_V0;
+}
+
 /*Fermi-Dirac kernel for below*/
 static double
 fermi_dirac_kernel(double x, void * params)
@@ -46,16 +44,16 @@ fermi_dirac_kernel(double x, void * params)
 
 /*Initialise the probability tables*/
 double
-init_thermalvel(const double v_amp, double max_fd,const double min_fd)
+init_thermalvel(struct thermalvel* thermals, const double v_amp, double max_fd,const double min_fd)
 {
     int i;
     if(max_fd <= min_fd)
         endrun(1,"Thermal vel called with negative interval: %g <= %g\n", max_fd, min_fd);
     /*Allocate random number generator*/
-    g_rng = gsl_rng_alloc(gsl_rng_mt19937);
+    thermals->g_rng = gsl_rng_alloc(gsl_rng_mt19937);
     if(max_fd > MAX_FERMI_DIRAC)
         max_fd = MAX_FERMI_DIRAC;
-    m_vamp = v_amp;
+    thermals->m_vamp = v_amp;
 
     /*These functions are so smooth that we don't need much space*/
     gsl_integration_workspace * w = gsl_integration_workspace_alloc (100);
@@ -64,8 +62,8 @@ init_thermalvel(const double v_amp, double max_fd,const double min_fd)
     F.function = &fermi_dirac_kernel;
     F.params = NULL;
     for(i = 0; i < LENGTH_FERMI_DIRAC_TABLE; i++) {
-        fermi_dirac_vel[i] = min_fd+(max_fd-min_fd)* i / (LENGTH_FERMI_DIRAC_TABLE - 1.0);
-        gsl_integration_qag (&F, min_fd, fermi_dirac_vel[i], 0, 1e-6,100,GSL_INTEG_GAUSS61, w,&(fermi_dirac_cumprob[i]), &abserr);
+        thermals->fermi_dirac_vel[i] = min_fd+(max_fd-min_fd)* i / (LENGTH_FERMI_DIRAC_TABLE - 1.0);
+        gsl_integration_qag (&F, min_fd, thermals->fermi_dirac_vel[i], 0, 1e-6,100,GSL_INTEG_GAUSS61, w,&(thermals->fermi_dirac_cumprob[i]), &abserr);
     //       printf("gsl_integration_qng in fermi_dirac_init_nu. Result %g, error: %g, intervals: %lu\n",fermi_dirac_cumprob[i], abserr,w->size);
     }
     /*Save the largest cum. probability, pre-normalisation,
@@ -76,29 +74,29 @@ init_thermalvel(const double v_amp, double max_fd,const double min_fd)
 
     gsl_integration_workspace_free (w);
 
-    double total_frac = fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE-1]/total_fd;
+    double total_frac = thermals->fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE-1]/total_fd;
     //Normalise total integral to unity
     for(i = 0; i < LENGTH_FERMI_DIRAC_TABLE; i++)
-        fermi_dirac_cumprob[i] /= fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE - 1];
+        thermals->fermi_dirac_cumprob[i] /= thermals->fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE - 1];
 
     /*Initialise the GSL table*/
-    fd_intp = gsl_interp_alloc(gsl_interp_cspline,LENGTH_FERMI_DIRAC_TABLE);
-    fd_intp_acc = gsl_interp_accel_alloc();
-    gsl_interp_init(fd_intp,fermi_dirac_cumprob, fermi_dirac_vel,LENGTH_FERMI_DIRAC_TABLE);
+    thermals->fd_intp = gsl_interp_alloc(gsl_interp_cspline,LENGTH_FERMI_DIRAC_TABLE);
+    thermals->fd_intp_acc = gsl_interp_accel_alloc();
+    gsl_interp_init(thermals->fd_intp,thermals->fermi_dirac_cumprob, thermals->fermi_dirac_vel,LENGTH_FERMI_DIRAC_TABLE);
     return total_frac;
 }
 
 /*Add a randomly generated thermal speed in v_amp*(min_fd, max_fd) to a 3-velocity*/
 void
-add_thermal_speeds(float Vel[])
+add_thermal_speeds(struct thermalvel * thermals, float Vel[])
 {
-    const double p = gsl_rng_uniform (g_rng);
+    const double p = gsl_rng_uniform (thermals->g_rng);
     /*m_vamp multiples by the dimensional factor to get a velocity again.*/
-    const double v = m_vamp * gsl_interp_eval(fd_intp,fermi_dirac_cumprob, fermi_dirac_vel, p, fd_intp_acc);
+    const double v = thermals->m_vamp * gsl_interp_eval(thermals->fd_intp,thermals->fermi_dirac_cumprob, thermals->fermi_dirac_vel, p, thermals->fd_intp_acc);
 
     /*Random phase*/
-    const double phi = 2 * M_PI * gsl_rng_uniform (g_rng);
-    const double theta = acos(2 * gsl_rng_uniform (g_rng) - 1);
+    const double phi = 2 * M_PI * gsl_rng_uniform (thermals->g_rng);
+    const double theta = acos(2 * gsl_rng_uniform (thermals->g_rng) - 1);
 
     Vel[0] = v * sin(theta) * cos(phi);
     Vel[1] = v * sin(theta) * sin(phi);

--- a/genic/thermal.c
+++ b/genic/thermal.c
@@ -117,7 +117,7 @@ add_thermal_speeds(struct thermalvel * thermals, gsl_rng *g_rng, float Vel[])
     const double phi = 2 * M_PI * gsl_rng_uniform (g_rng);
     const double theta = acos(2 * gsl_rng_uniform (g_rng) - 1);
 
-    Vel[0] = v * sin(theta) * cos(phi);
-    Vel[1] = v * sin(theta) * sin(phi);
-    Vel[2] = v * cos(theta);
+    Vel[0] += v * sin(theta) * cos(phi);
+    Vel[1] += v * sin(theta) * sin(phi);
+    Vel[2] += v * cos(theta);
 }

--- a/genic/thermal.h
+++ b/genic/thermal.h
@@ -12,7 +12,6 @@ struct thermalvel
     double fermi_dirac_vel[LENGTH_FERMI_DIRAC_TABLE];
     double fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE];
     double m_vamp;
-    gsl_rng * g_rng;
     gsl_interp * fd_intp;
     gsl_interp_accel * fd_intp_acc;
 };
@@ -24,9 +23,10 @@ struct thermalvel
 double
 init_thermalvel(struct thermalvel * thermals, const double v_amp, double max_fd, const double min_fd);
 
-/*Add a randomly generated thermal speed in v_amp*(min_fd, max_fd) to a 3-velocity*/
+/*Add a randomly generated thermal speed in v_amp*(min_fd, max_fd) to a 3-velocity.
+ *Position seeds the rng.*/
 void
-add_thermal_speeds(struct thermalvel * thermals, float Vel[]);
+add_thermal_speeds(struct thermalvel * thermals, int64_t Id, float Vel[]);
 
 /*Amplitude of the random velocity for neutrinos*/
 double

--- a/genic/thermal.h
+++ b/genic/thermal.h
@@ -23,10 +23,9 @@ struct thermalvel
 double
 init_thermalvel(struct thermalvel * thermals, const double v_amp, double max_fd, const double min_fd);
 
-/*Add a randomly generated thermal speed in v_amp*(min_fd, max_fd) to a 3-velocity.
- *Position seeds the rng.*/
+/*Add a randomly generated thermal speed in v_amp*(min_fd, max_fd) to a 3-velocity.*/
 void
-add_thermal_speeds(struct thermalvel * thermals, int64_t Id, float Vel[]);
+add_thermal_speeds(struct thermalvel * thermals, gsl_rng *g_rng, float Vel[]);
 
 /*Amplitude of the random velocity for neutrinos*/
 double
@@ -35,4 +34,9 @@ NU_V0(const double Time, const double kBTNubyMNu, const double UnitVelocity_in_c
 /*Amplitude of the random velocity for WDM*/
 double
 WDM_V0(const double Time, const double WDM_therm_mass, const double Omega_CDM, const double HubbleParam, const double UnitVelocity_in_cm_per_s);
+
+unsigned int *
+init_rng(int Seed, int Nmesh);
+
+
 #endif

--- a/genic/thermal.h
+++ b/genic/thermal.h
@@ -1,19 +1,38 @@
 #ifndef THERMALVEL_H
 #define THERMALVEL_H
 
+#include <gsl/gsl_interp.h>
+#include <gsl/gsl_rng.h>
+/*Length of the table*/
+#define MAX_FERMI_DIRAC          17.0
+#define LENGTH_FERMI_DIRAC_TABLE 2000
+
+struct thermalvel
+{
+    double fermi_dirac_vel[LENGTH_FERMI_DIRAC_TABLE];
+    double fermi_dirac_cumprob[LENGTH_FERMI_DIRAC_TABLE];
+    double m_vamp;
+    gsl_rng * g_rng;
+    gsl_interp * fd_intp;
+    gsl_interp_accel * fd_intp_acc;
+};
+
 /*Single parameter is the amplitude of the random velocities. All the physics is in here.
  * max_fd and min_fd give the maximum and minimum velocities to integrate over.
  * Note these values are dimensionless*/
 /*Returns total fraction of the Fermi-Dirac distribution between max_fd and min_fd*/
 double
-init_thermalvel(const double v_amp, double max_fd, const double min_fd);
+init_thermalvel(struct thermalvel * thermals, const double v_amp, double max_fd, const double min_fd);
 
 /*Add a randomly generated thermal speed in v_amp*(min_fd, max_fd) to a 3-velocity*/
 void
-add_thermal_speeds(float Vel[]);
+add_thermal_speeds(struct thermalvel * thermals, float Vel[]);
 
 /*Amplitude of the random velocity for neutrinos*/
 double
 NU_V0(const double Time, const double kBTNubyMNu, const double UnitVelocity_in_cm_per_s);
 
+/*Amplitude of the random velocity for WDM*/
+double
+WDM_V0(const double Time, const double WDM_therm_mass, const double Omega_CDM, const double HubbleParam, const double UnitVelocity_in_cm_per_s);
 #endif

--- a/genic/zeldovich.c
+++ b/genic/zeldovich.c
@@ -48,7 +48,7 @@ void free_ffts(void)
 }
 
 void
-setup_grid(double shift, int64_t FirstID)
+setup_grid(double shift, int64_t FirstID, int Ngrid)
 {
     int * ThisTask2d = petapm_get_thistask2d();
     int * NTask2d = petapm_get_ntask2d();

--- a/param.c
+++ b/param.c
@@ -283,6 +283,8 @@ create_gadget_parameter_set()
     param_declare_double(ps, "WindFreeTravelLength", OPTIONAL, 20, "");
     param_declare_double(ps, "WindFreeTravelDensFac", OPTIONAL, 0., "");
 
+    param_declare_int(ps, "RandomSeed", OPTIONAL, 42, "Random number generator initial seed. Used to form stars.");
+
     /*These parameters are Lyman alpha forest specific*/
     param_declare_double(ps, "QuickLymanAlphaProbability", OPTIONAL, 0, "Probability gas is turned directly into stars, irrespective of pressure. One is equivalent to quick lyman alpha star formation.");
     /* Enable model for helium reionisation which adds extra photo-heating to under-dense gas.
@@ -424,6 +426,8 @@ void read_parameter_file(char *fname)
         All.FOFHaloMinLength = param_get_int(ps, "FOFHaloMinLength");
         All.MinFoFMassForNewSeed = param_get_double(ps, "MinFoFMassForNewSeed");
         All.TimeBetweenSeedingSearch = param_get_double(ps, "TimeBetweenSeedingSearch");
+
+        All.RandomSeed = param_get_int(ps, "RandomSeed");
 
         All.BlackHoleOn = param_get_int(ps, "BlackHoleOn");
     #ifdef BLACK_HOLES

--- a/run.c
+++ b/run.c
@@ -107,7 +107,7 @@ void run(void)
 
         print_timebin_statistics(NumCurrentTiStep);
 
-        set_random_numbers();
+        set_random_numbers(All.RandomSeed + All.Ti_Current);
 
         /* update force to Ti_Current */
         compute_accelerations(is_PM, NumCurrentTiStep == 0, GasEnabled);

--- a/system.c
+++ b/system.c
@@ -121,11 +121,11 @@ double get_random_number(uint64_t id)
     return RndTable[(int)(id % RNDTABLE)];
 }
 
-void set_random_numbers(void)
+void set_random_numbers(int seed)
 {
     random_generator = gsl_rng_alloc(gsl_rng_ranlxd1);
 
-    gsl_rng_set(random_generator, 42);	/* start-up seed */
+    gsl_rng_set(random_generator, seed);	/* start-up seed */
 
     int i;
 

--- a/system.h
+++ b/system.h
@@ -21,7 +21,7 @@ int cluster_get_hostid();
 double get_physmem_bytes();
 
 double get_random_number(uint64_t id);
-void set_random_numbers(void);
+void set_random_numbers(int seed);
 void sumup_large_ints(int n, int *src, int64_t *res);
 void sumup_longs(int n, int64_t *src, int64_t *res);
 int64_t count_sum(int64_t countLocal);

--- a/tests/test_genic-thermal.c
+++ b/tests/test_genic-thermal.c
@@ -49,9 +49,10 @@ test_thermal_vel(void ** state)
     int nsample;
     float Vel[3] = {0};
     int64_t MaxID = 100000;
+    gsl_rng * g_rng = gsl_rng_alloc(gsl_rng_ranlxd1);
     for (nsample=0; nsample < MaxID; nsample++)
     {
-        add_thermal_speeds(&nu_vels, nsample, Vel);
+        add_thermal_speeds(&nu_vels, g_rng, Vel);
         double v2 = sqrt(Vel[0]*Vel[0]+Vel[1]*Vel[1]+Vel[2]*Vel[2]);
         if(v2 > max)
             max = v2;
@@ -60,6 +61,7 @@ test_thermal_vel(void ** state)
         mean+=v2;
         memset(Vel, 0, 3*sizeof(float));
     }
+    gsl_rng_free(g_rng);
     mean/=nsample;
     /*Mean should be roughly 3*zeta(4)/zeta(3)*7/8/(3/4)* m_vamp*/
     assert_true(fabs(mean - 3*pow(M_PI,4)/90./1.202057*(7./8)/(3/4.)*100) < 1);

--- a/tests/test_genic-thermal.c
+++ b/tests/test_genic-thermal.c
@@ -1,0 +1,76 @@
+/*Tests for the thermal velocity module, ported from S-GenIC.*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "stub.h"
+#include "config.h"
+#include "genic/thermal.h"
+
+/*Check that the neutrino velocity NU_V0 is sensible*/
+static void
+test_mean_velocity(void ** state)
+{
+    /*Check has units of velocity*/
+    assert_true(fabs(NU_V0(1, 1, 1e3) - 100*NU_V0(1, 1, 1e5)) < 1e-6);
+    /*Check scales linearly with neutrino mass*/
+    assert_true(fabs(10*NU_V0(1, 0.1, 1e5) - NU_V0(1, 1, 1e5)) < 1e-6);
+    /*Check scales as z (gadget's cosmological velocity unit is accounted for outside)*/
+    assert_true(fabs(0.5*NU_V0(0.5, 1, 1e5) -  NU_V0(1, 1, 1e5)) < 1e-6);
+}
+
+static void
+test_thermal_vel(void ** state)
+{
+    /*Seed table with velocity of 100 km/s*/
+    struct thermalvel nu_vels;
+    init_thermalvel(&nu_vels, 100, 5000/100, 0);
+
+    /*Test getting the distribution*/
+    assert_true(fabs(nu_vels.fermi_dirac_vel[0]) < 1e-6);
+    assert_true(fabs(nu_vels.fermi_dirac_vel[LENGTH_FERMI_DIRAC_TABLE - 1] -  MAX_FERMI_DIRAC) < 1e-3);
+
+    /*Number verified by mathematica*/
+    int ii = 0;
+    while(nu_vels.fermi_dirac_cumprob[ii] < 0.5) {
+        ii++;
+    }
+    assert_true(fabs(nu_vels.fermi_dirac_vel[ii] - 2.839075) < 0.002);
+    /*Check some statistical properties (max, min, mean)*/
+    double mean = 0;
+    double max = 0;
+    double min = 1e10;
+    int nsample;
+    float Vel[3] = {0};
+    int64_t MaxID = 100000;
+    for (nsample=0; nsample < MaxID; nsample++)
+    {
+        add_thermal_speeds(&nu_vels, nsample, Vel);
+        double v2 = sqrt(Vel[0]*Vel[0]+Vel[1]*Vel[1]+Vel[2]*Vel[2]);
+        if(v2 > max)
+            max = v2;
+        if(v2 < min)
+            min = v2;
+        mean+=v2;
+        memset(Vel, 0, 3*sizeof(float));
+    }
+    mean/=nsample;
+    /*Mean should be roughly 3*zeta(4)/zeta(3)*7/8/(3/4)* m_vamp*/
+    assert_true(fabs(mean - 3*pow(M_PI,4)/90./1.202057*(7./8)/(3/4.)*100) < 1);
+    assert_true(min > 0);
+    assert_true( max < MAX_FERMI_DIRAC*100);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_mean_velocity),
+        cmocka_unit_test(test_thermal_vel)
+    };
+    return cmocka_run_group_tests_mpi(tests, NULL, NULL);
+}


### PR DESCRIPTION
Once again allow adding thermal velocities corresponding to warm dark matter to the initial CDM distribution. Do not alter the power spectrum though - that is best done externally.