### PR TITLE
Refactor fof slightly to reduce peak memory usage

### DIFF
--- a/fof.c
+++ b/fof.c
@@ -77,6 +77,10 @@ static void
 fof_compile_base(struct BaseGroup * base);
 static void
 fof_compile_catalogue(struct Group * group);
+
+static struct Group *
+fof_alloc_group(const struct BaseGroup * base, const uint64_t NgroupsExt);
+
 static void fof_assign_grnr(struct BaseGroup * base);
 
 void fof_label_primary(void);
@@ -186,15 +190,8 @@ void fof_fof()
 
     t0 = second();
 
-    Group = (struct Group *) mymalloc2("Group", sizeof(struct Group) * NgroupsExt);
-    memset(Group, 0, sizeof(Group[0]) * NgroupsExt);
-
-    /* copy in the base properties */
-    /* at this point base group shall be sorted by MinID */
-    #pragma omp parallel for
-    for(i = 0; i < NgroupsExt; i ++) {
-        Group[i].base = base[i];
-    }
+    /*Initialise the Group object from the BaseGroup*/
+    Group = fof_alloc_group(base, NgroupsExt);
 
     myfree(base);
 
@@ -683,6 +680,23 @@ fof_compile_base(struct BaseGroup * base)
     }
 }
 
+/* Allocate memory for and initialise a Group object
+ * from a BaseGroup object.*/
+static struct Group *
+fof_alloc_group(const struct BaseGroup * base, const uint64_t NgroupsExt)
+{
+    int i;
+    struct Group * Group = (struct Group *) mymalloc2("Group", sizeof(struct Group) * NgroupsExt);
+    memset(Group, 0, sizeof(Group[0]) * NgroupsExt);
+
+    /* copy in the base properties */
+    /* at this point base group shall be sorted by MinID */
+    #pragma omp parallel for
+    for(i = 0; i < NgroupsExt; i ++) {
+        Group[i].base = base[i];
+    }
+    return Group;
+}
 
 static void
 fof_compile_catalogue(struct Group * group)

--- a/fof.c
+++ b/fof.c
@@ -36,7 +36,7 @@
 /* FIXME: convert this to a parameter */
 #define FOF_SECONDARY_LINK_TYPES (1+16+32)    // 2^type for the types linked to nearest primaries
 #define LARGE 1e29
-void fof_init()
+void fof_init(void)
 {
     All.FOFHaloComovingLinkingLength = All.FOFHaloLinkingLength * All.MeanSeparation[1];
     All.TimeNextSeedingCheck = All.Time;
@@ -87,7 +87,6 @@ void fof_label_primary(void);
 extern void fof_save_particles(int num);
 
 uint64_t Ngroups, TotNgroups, NgroupsExt;
-int64_t TotNids;
 
 struct Group *Group;
 
@@ -125,7 +124,7 @@ static MPI_Datatype MPI_TYPE_GROUP;
  *
  **/
 
-void fof_fof()
+void fof_fof(void)
 {
     int i;
     double t0, t1;
@@ -739,6 +738,7 @@ fof_compile_catalogue(struct Group * group)
 
     fof_finish_group_properties(Group);
 
+    int64_t TotNids;
     MPI_Allreduce(&Ngroups, &TotNgroups, 1, MPI_UINT64, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&Nids, &TotNids, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
 

--- a/fof.h
+++ b/fof.h
@@ -3,21 +3,24 @@
 
 #include "allvars.h"
 
-void fof_init();
+void fof_init(void);
 
-void fof_fof();
+/*Computes the Group structure, saved as a global array below*/
+void fof_fof(void);
 
+/*Frees the Group structure*/
 void
-fof_finish();
+fof_finish(void);
 
+/*Uses the Group structure to seed blackholes*/
 void
-fof_seed();
+fof_seed(void);
 
+/*Saves the Group structure to disc.*/
 void
 fof_save_groups(int num);
 
 extern uint64_t Ngroups, TotNgroups;
-extern int64_t TotNids;
 
 struct BaseGroup {
     int OriginalTask;
@@ -29,9 +32,9 @@ struct BaseGroup {
     float FirstPos[3];
 };
 
-extern struct Group 
+extern struct Group
 {
-    struct BaseGroup base; 
+    struct BaseGroup base;
     int Length;
     int LenType[6];
     double MassType[6];
@@ -50,7 +53,7 @@ extern struct Group
     double BH_Mdot;
     double MaxDens;
 #endif
-    int seed_index; 
+    int seed_index;
     int seed_task;
 } * Group;
 

--- a/main.c
+++ b/main.c
@@ -97,6 +97,8 @@ int main(int argc, char **argv)
         case 3:
             begrun(RestartSnapNum); 
             fof_fof(RestartSnapNum);
+            fof_save_groups(RestartSnapNum);
+            fof_finish();
             break;
         case 99:
             begrun(RestartSnapNum);

--- a/main.c
+++ b/main.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
     switch(RestartFlag) {
         case 3:
             begrun(RestartSnapNum); 
-            fof_fof(RestartSnapNum);
+            fof_fof();
             fof_save_groups(RestartSnapNum);
             fof_finish();
             break;

--- a/run.c
+++ b/run.c
@@ -20,7 +20,6 @@
 #include "hydra.h"
 #include "sfr_eff.h"
 #include "slotsmanager.h"
-#include "fof.h"
 #include "hci.h"
 
 /*! \file run.c


### PR DESCRIPTION
Avoid allocating memory for qsort when base is still allocated.

I had a simulation recently where this was the point of peak memory usage: moving the allocation a little later helped, because there is no qsort allocation with both Base and Group allocated.