### PR TITLE
Petamem

### DIFF
--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -36,14 +36,14 @@ struct Layout {
     int * ibuffer;
 };
 
-static void layout_prepare (struct Layout * L);
+static void layout_prepare (struct Layout * L, double * meshbuf, PetaPMRegion * regions, const int Nregions);
 static void layout_finish(struct Layout * L);
-static void layout_build_and_exchange_cells_to_pfft(struct Layout * L);
-static void layout_build_and_exchange_cells_to_local(struct Layout * L);
+static void layout_build_and_exchange_cells_to_pfft(struct Layout * L, double * meshbuf, double * real);
+static void layout_build_and_exchange_cells_to_local(struct Layout * L, double * meshbuf, double * real);
 
-/* cell_iterator nees to be thread safe !*/
+/* cell_iterator needs to be thread safe !*/
 typedef void (* cell_iterator)(double * cell_value, double * comm_buffer);
-static void layout_iterate_cells(struct Layout * L, cell_iterator iter);
+static void layout_iterate_cells(struct Layout * L, cell_iterator iter, double * real);
 
 struct Pencil { /* a pencil starting at offset, with lenght len */
     int offset[3];
@@ -75,12 +75,13 @@ static int Nmesh;
 static int NTask;
 static int ThisTask;
 
-/* there variables are allocated every force calculation */
+/* these variables are allocated every force calculation */
 static double * real;
 static double * meshbuf;
 static size_t meshbufsize;
 static pfft_complex * complx;
 static pfft_complex * rho_k;
+
 static void pm_alloc();
 static void pm_free();
 
@@ -190,7 +191,9 @@ void petapm_init(double BoxSize, int _Nmesh, int Nthreads) {
 
     /* planning the fft; need temporary arrays */
 
-    pm_alloc();
+    double * real = (double * ) mymalloc("PMreal", fftsize * sizeof(double));
+    pfft_complex * rho_k = (pfft_complex * ) mymalloc("PMrho_k", fftsize * sizeof(double));
+    pfft_complex * complx = (pfft_complex *) mymalloc("PMcomplex", fftsize * sizeof(double));
 
     plan_forw = pfft_plan_dft_r2c_3d(
         n, real, rho_k, comm_cart_2d, PFFT_FORWARD, 
@@ -199,7 +202,9 @@ void petapm_init(double BoxSize, int _Nmesh, int Nthreads) {
         n, complx, real, comm_cart_2d, PFFT_BACKWARD, 
         PFFT_TRANSPOSED_IN | PFFT_ESTIMATE | PFFT_TUNE | PFFT_DESTROY_INPUT);
 
-    pm_free();
+    myfree(complx);
+    myfree(rho_k);
+    myfree(real);
 
     /* now lets fill up the mesh2task arrays */
 
@@ -238,7 +243,7 @@ void petapm_init(double BoxSize, int _Nmesh, int Nthreads) {
  * (particle i is never done by same thread)
  * */
 typedef void (* pm_iterator)(int i, double * mesh, double weight);
-static void pm_iterate(pm_iterator iterator);
+static void pm_iterate(pm_iterator iterator, PetaPMRegion * regions);
 /* apply transfer function to value, kpos array is in x, y, z order */
 typedef void (*transfer_function) (int64_t k2, int kpos[3], pfft_complex * value);
 static void pm_apply_transfer_function(PetaPMRegion * fourier_space_region, 
@@ -276,12 +281,12 @@ void petapm_force_init(
     memset(meshbuf, 0, meshbufsize * sizeof(double));
 
     walltime_measure("/PMgrav/Misc");
-    pm_iterate(put_particle_to_mesh);
+    pm_iterate(put_particle_to_mesh, regions);
     walltime_measure("/PMgrav/cic");
 
-    layout_prepare(&layout);
+    layout_prepare(&layout, meshbuf, regions, Nregions);
 
-    layout_build_and_exchange_cells_to_pfft(&layout);
+    layout_build_and_exchange_cells_to_pfft(&layout, meshbuf, real);
     walltime_measure("/PMgrav/comm");
 #ifdef DEBUG
     verify_density_field();
@@ -319,17 +324,17 @@ void petapm_force_c2r(
     for (f = functions; f->name; f ++) {
         petapm_transfer_func transfer = f->transfer;
         petapm_readout_func readout = f->readout;
-        /* apply the greens functionb turn rho_k into potential in fourier space */
+        /* apply the greens function turn rho_k into potential in fourier space */
         pm_apply_transfer_function(&fourier_space_region, rho_k, complx, transfer);
 
         walltime_measure("/PMgrav/calc");
         pfft_execute_dft_c2r(plan_back, complx, real);
         walltime_measure("/PMgrav/c2r");
         /* read out the potential */
-        layout_build_and_exchange_cells_to_local(&layout);
+        layout_build_and_exchange_cells_to_local(&layout, meshbuf, real);
         walltime_measure("/PMgrav/comm");
         
-        pm_iterate(readout);
+        pm_iterate(readout, regions);
         walltime_measure("/PMgrav/readout");
     }
 
@@ -358,9 +363,9 @@ void petapm_force(petapm_prepare_func prepare,
     
 /* build a communication layout */
 
-static void layout_build_pencils(struct Layout * L);
+static void layout_build_pencils(struct Layout * L, double * meshbuf, PetaPMRegion * regions, const int Nregions);
 static void layout_exchange_pencils(struct Layout * L);
-static void layout_prepare (struct Layout * L) {
+static void layout_prepare (struct Layout * L, double * meshbuf, PetaPMRegion * regions, const int Nregions) {
     int r;
     int i;
 
@@ -389,7 +394,7 @@ static void layout_prepare (struct Layout * L) {
 
     L->PencilSend = mymalloc("PencilSend", NpAlloc * sizeof(struct Pencil));
 
-    layout_build_pencils(L);
+    layout_build_pencils(L, meshbuf, regions, Nregions);
 
     /* sort the pencils by the target rank for ease of next step */
     qsort_openmp(L->PencilSend, NpAlloc, sizeof(struct Pencil), pencil_cmp_target);
@@ -461,7 +466,7 @@ static void layout_prepare (struct Layout * L) {
     layout_exchange_pencils(L);
 }
 
-static void layout_build_pencils(struct Layout * L) {
+static void layout_build_pencils(struct Layout * L, double * meshbuf, PetaPMRegion * regions, const int Nregions) {
     /* now build pencils to be exported */
     int p0 = 0;
     int r;
@@ -557,7 +562,7 @@ static void to_pfft(double * cell, double * buf) {
 #pragma omp atomic
             cell[0] += buf[0];
 }
-static void layout_build_and_exchange_cells_to_pfft(struct Layout * L) {
+static void layout_build_and_exchange_cells_to_pfft(struct Layout * L, double * meshbuf, double * real) {
     L->BufSend = mymalloc("PMBufSend", L->NcExport * sizeof(double));
     L->BufRecv = mymalloc("PMBufRecv", L->NcImport * sizeof(double));
 
@@ -568,7 +573,7 @@ static void layout_build_and_exchange_cells_to_pfft(struct Layout * L) {
     offset = 0;
     for(i = 0; i < L->NpExport; i ++) {
         struct Pencil * p = &L->PencilSend[i];
-        memcpy(L->BufSend + offset, &meshbuf[p->meshbuf_first], 
+        memcpy(L->BufSend + offset, &meshbuf[p->meshbuf_first],
                 sizeof(double) * p->len);
         offset += p->len;
     }
@@ -596,7 +601,7 @@ static void layout_build_and_exchange_cells_to_pfft(struct Layout * L) {
     message(0, "totmassExport = %g totmassImport = %g\n", totmassExport, totmassImport);
 #endif
 
-    layout_iterate_cells(L, to_pfft);
+    layout_iterate_cells(L, to_pfft, real);
     myfree(L->BufRecv);
     myfree(L->BufSend);
 }
@@ -607,13 +612,13 @@ static void to_region(double * cell, double * region) {
     *region = *cell;
 }
 
-static void layout_build_and_exchange_cells_to_local(struct Layout * L) {
+static void layout_build_and_exchange_cells_to_local(struct Layout * L, double * meshbuf, double * real) {
     L->BufSend = mymalloc("PMBufSend", L->NcExport * sizeof(double));
     L->BufRecv = mymalloc("PMBufRecv", L->NcImport * sizeof(double));
     int i;
     int offset;
 
-    layout_iterate_cells(L, to_region);
+    layout_iterate_cells(L, to_region, real);
 
     /* exchange cells */
     /* notice the order is reversed from to_pfft */
@@ -626,7 +631,7 @@ static void layout_build_and_exchange_cells_to_local(struct Layout * L) {
     offset = 0;
     for(i = 0; i < L->NpExport; i ++) {
         struct Pencil * p = &L->PencilSend[i];
-        memcpy(&meshbuf[p->meshbuf_first], 
+        memcpy(&meshbuf[p->meshbuf_first],
                 L->BufSend + offset, 
                 sizeof(double) * p->len);
         offset += p->len;
@@ -639,7 +644,7 @@ static void layout_build_and_exchange_cells_to_local(struct Layout * L) {
  *
  * !!! iter has to be thread safe. !!!
  * */
-static void layout_iterate_cells(struct Layout * L, cell_iterator iter) {
+static void layout_iterate_cells(struct Layout * L, cell_iterator iter, double * real) {
     int i;
 #pragma omp parallel for
     for(i = 0; i < L->NpImport; i ++) {
@@ -663,7 +668,7 @@ static void layout_iterate_cells(struct Layout * L, cell_iterator iter) {
             while(iz < 0) iz += Nmesh;
             while(iz >= Nmesh) iz -= Nmesh;
             if(iz >= real_space_region.size[2]) {
-                /* seroius problem assmpution about pfft layout was wrong*/
+                /* serious problem assmpution about pfft layout was wrong*/
                 abort();
             }
             ptrdiff_t linear = iz * real_space_region.strides[2] + linear0;
@@ -697,7 +702,7 @@ static void pm_alloc() {
 }
 
 
-static void pm_iterate_one(int i, pm_iterator iterator) {
+static void pm_iterate_one(int i, pm_iterator iterator, PetaPMRegion * regions) {
     int k;
     int iCell[3];  /* integer coordinate on the regional mesh */
     double Res[3]; /* residual*/
@@ -760,11 +765,11 @@ static void pm_iterate_one(int i, pm_iterator iterator) {
  * no threads run on same particle same time but may 
  * access one mesh points same time.
  * */
-static void pm_iterate(pm_iterator iterator) {
+static void pm_iterate(pm_iterator iterator, PetaPMRegion * regions) {
     int i;
 #pragma omp parallel for 
     for(i = 0; i < CPS->NumPart; i ++) {
-        pm_iterate_one(i, iterator); 
+        pm_iterate_one(i, iterator, regions); 
     }
     MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/libgadget/petapm.c
+++ b/libgadget/petapm.c
@@ -81,9 +81,6 @@ static size_t meshbufsize;
 
 static void pm_init_regions(PetaPMRegion * regions, const int Nregions);
 
-//static PetaPMRegion * regions = NULL; /* created by 'prepare' callback in petapm_force */
-//static int Nregions = 0;
-
 static PetaPMParticleStruct * CPS; /* stored by petapm_force, how to access the P array */
 #define POS(i) ((double*)  (&((char*)CPS->Parts)[CPS->elsize * (i) + CPS->offset_pos]))
 #define MASS(i) ((float*) (&((char*)CPS->Parts)[CPS->elsize * (i) + CPS->offset_mass]))

--- a/libgadget/petapm.h
+++ b/libgadget/petapm.h
@@ -50,14 +50,14 @@ void petapm_force(petapm_prepare_func prepare,
         PetaPMParticleStruct * pstruct,
         void * userdata);
 
-void petapm_force_init(
+PetaPMRegion * petapm_force_init(
         petapm_prepare_func prepare, 
         PetaPMParticleStruct * pstruct,
         void * userdata);
 pfft_complex * petapm_force_r2c(
         PetaPMGlobalFunctions * global_functions
         );
-void petapm_force_c2r(pfft_complex * rho_k,
+void petapm_force_c2r(pfft_complex * rho_k, PetaPMRegion * regions,
         PetaPMFunctions * functions);
 void petapm_force_finish();
 PetaPMRegion * petapm_get_fourier_region();

--- a/libgadget/petapm.h
+++ b/libgadget/petapm.h
@@ -54,14 +54,16 @@ void petapm_force_init(
         petapm_prepare_func prepare, 
         PetaPMParticleStruct * pstruct,
         void * userdata);
-void petapm_force_r2c(
+pfft_complex * petapm_force_r2c(
         PetaPMGlobalFunctions * global_functions
         );
-void petapm_force_c2r(
+void petapm_force_c2r(pfft_complex * rho_k,
         PetaPMFunctions * functions);
 void petapm_force_finish();
 PetaPMRegion * petapm_get_fourier_region();
 PetaPMRegion * petapm_get_real_region();
+/* Danger: this function allocates memory for an empty rho_k array.
+ * The memory is normally freed at the end of petapm_force_c2r*/
 pfft_complex * petapm_get_rho_k();
 int petapm_mesh_to_k(int i);
 int *petapm_get_thistask2d();

--- a/libgadget/petapm.h
+++ b/libgadget/petapm.h
@@ -54,7 +54,7 @@ void petapm_force_init(
         petapm_prepare_func prepare, 
         PetaPMParticleStruct * pstruct,
         void * userdata);
-void petapm_force_r2c( 
+void petapm_force_r2c(
         PetaPMGlobalFunctions * global_functions
         );
 void petapm_force_c2r(

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -82,7 +82,7 @@ setup_grid(double shift, int64_t FirstID, int Ngrid)
 }
 
 static PetaPMRegion * makeregion(void * userdata, int * Nregions) {
-    PetaPMRegion * regions = mymalloc("Regions", sizeof(PetaPMRegion));
+    PetaPMRegion * regions = mymalloc2("Regions", sizeof(PetaPMRegion));
     int k;
     int r = 0;
     int i;
@@ -133,7 +133,7 @@ void displacement_fields(int Type) {
         NULL,
         NumPart,
     };
-    petapm_force_init(
+    PetaPMRegion * regions = petapm_force_init(
            makeregion,
            &pstruct, NULL);
 
@@ -142,7 +142,7 @@ void displacement_fields(int Type) {
     gaussian_fill(petapm_get_fourier_region(),
 		  rho_k, All2.UnitaryAmplitude, All2.InvertPhase);
 
-    petapm_force_c2r(rho_k, functions);
+    petapm_force_c2r(rho_k, regions, functions);
     petapm_force_finish();
     double maxdisp = 0;
     int i;

--- a/libgenic/zeldovich.c
+++ b/libgenic/zeldovich.c
@@ -137,10 +137,12 @@ void displacement_fields(int Type) {
            makeregion,
            &pstruct, NULL);
 
+    /*This allocates the memory*/
+    pfft_complex * rho_k = petapm_get_rho_k();
     gaussian_fill(petapm_get_fourier_region(),
-		  petapm_get_rho_k(), All2.UnitaryAmplitude, All2.InvertPhase);
+		  rho_k, All2.UnitaryAmplitude, All2.InvertPhase);
 
-    petapm_force_c2r(functions);
+    petapm_force_c2r(rho_k, functions);
     petapm_force_finish();
     double maxdisp = 0;
     int i;


### PR DESCRIPTION
This PR performs a bit of housekeeping in petapm.

It makes some variables that were previously global statics local. It then uses the double-ended malloc to reduce the peak memory usage in MP-GenIC by 2 * fftsize * sizeof(double).